### PR TITLE
Changing CentOS URLs to variables to allow for local use on local fil…

### DIFF
--- a/centos6/centos6.json
+++ b/centos6/centos6.json
@@ -1,11 +1,16 @@
 {
+    "variables":
+        {
+            "centos6_iso_url": "https://mirrors.edge.kernel.org/centos/6.10/isos/x86_64/CentOS-6.10-x86_64-netinstall.iso",
+            "centos6_sha256sum_url": "https://mirrors.edge.kernel.org/centos/6.10/isos/x86_64/sha256sum.txt"
+        },
     "builders": [
         {
             "type": "qemu",
             "communicator": "none",
-            "iso_url": "https://mirrors.edge.kernel.org/centos/6.10/isos/x86_64/CentOS-6.10-x86_64-netinstall.iso",
+            "iso_url": "{{user `centos6_iso_url`}}",
             "iso_checksum_type": "sha256",
-            "iso_checksum_url": "https://mirrors.edge.kernel.org/centos/6.10/isos/x86_64/sha256sum.txt",
+            "iso_checksum_url": "{{user `centos6_sha256sum_url`}}",
             "boot_command": [
                 "<tab> ",
                 "ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos6.ks ",

--- a/centos7/centos7.json
+++ b/centos7/centos7.json
@@ -1,11 +1,16 @@
 {
+    "variables":
+        {
+            "centos7_iso_url": "https://mirrors.edge.kernel.org/centos/7.7.1908/isos/x86_64/CentOS-7-x86_64-NetInstall-1908.iso",
+            "centos7_sha256sum_url": "https://mirrors.edge.kernel.org/centos/7.7.1908/isos/x86_64/sha256sum.txt"
+        },
     "builders": [
         {
             "type": "qemu",
             "communicator": "none",
-            "iso_url": "https://mirrors.edge.kernel.org/centos/7.7.1908/isos/x86_64/CentOS-7-x86_64-NetInstall-1908.iso",
+            "iso_url": "{{user `centos7_iso_url`}}",
             "iso_checksum_type": "sha256",
-            "iso_checksum_url": "https://mirrors.edge.kernel.org/centos/7.7.1908/isos/x86_64/sha256sum.txt",
+            "iso_checksum_url": "{{user `centos7_sha256sum_url`}}",
             "boot_command": [
                 "<tab> ",
                 "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos7.ks ",

--- a/centos8/centos8.json
+++ b/centos8/centos8.json
@@ -1,11 +1,16 @@
 {
+    "variables":
+        {
+            "centos8_iso_url": "https://mirrors.edge.kernel.org/centos/8.1.1911/isos/x86_64/CentOS-8.1.1911-x86_64-boot.iso",
+            "centos8_sha256sum_url": "https://mirrors.edge.kernel.org/centos/8.1.1911/isos/x86_64/CHECKSUM"
+        },
     "builders": [
         {
             "type": "qemu",
             "communicator": "none",
-            "iso_url": "https://mirrors.edge.kernel.org/centos/8.1.1911/isos/x86_64/CentOS-8.1.1911-x86_64-boot.iso",
+            "iso_url": "{{user `centos8_iso_url`}}",
             "iso_checksum_type": "sha256",
-            "iso_checksum_url": "https://mirrors.edge.kernel.org/centos/8.1.1911/isos/x86_64/CHECKSUM",
+            "iso_checksum_url": "{{user `centos8_sha256sum_url`}}",
             "boot_command": [
                 "<tab> ",
                 "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos8.ks ",

--- a/rhel7/rhel7.json
+++ b/rhel7/rhel7.json
@@ -6,7 +6,7 @@
         {
             "type": "qemu",
             "communicator": "none",
-	    "iso_url": "{{user `rhel7_iso_path`}}",
+            "iso_url": "{{user `rhel7_iso_path`}}",
             "iso_checksum_type": "none",
             "boot_command": [
                 "<tab> ",


### PR DESCRIPTION
This PR adds variables to the CentOS templates to allow for users to specify local .iso downloads or to specify a different mirror if necessary.  I also fixed a type s/\t/  / in the rhel7 template.