### PR TITLE
Updating to CentOS 7.8

### DIFF
--- a/centos7/centos7.json
+++ b/centos7/centos7.json
@@ -3,9 +3,9 @@
         {
             "type": "qemu",
             "communicator": "none",
-            "iso_url": "https://mirrors.edge.kernel.org/centos/7.7.1908/isos/x86_64/CentOS-7-x86_64-NetInstall-1908.iso",
+            "iso_url": "https://mirrors.edge.kernel.org/centos/7.8.2003/isos/x86_64/CentOS-7-x86_64-NetInstall-2003.iso",
             "iso_checksum_type": "sha256",
-            "iso_checksum_url": "https://mirrors.edge.kernel.org/centos/7.7.1908/isos/x86_64/sha256sum.txt",
+            "iso_checksum_url": "https://mirrors.edge.kernel.org/centos/7.8.2003/isos/x86_64/sha256sum.txt",
             "boot_command": [
                 "<tab> ",
                 "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos7.ks ",


### PR DESCRIPTION
This PR Updates the ISO/Checksum URLs to point to CentOS 7.8 instead of 7.7