### PR TITLE
Adds support for ESXi 7

### DIFF
--- a/vmware-esxi/README.md
+++ b/vmware-esxi/README.md
@@ -8,9 +8,8 @@
 * A machine running Ubuntu 18.04+ with the ability to run KVM virtual machines.
 * qemu-utils
 * parted
-
-* [Packer.](https://www.packer.io/intro/getting-started/install.html)
-* The VMware ESXi installation ISO must be downloaded manually. You can download it [here.](https://www.vmware.com/go/get-free-esxi)
+* [Packer](https://www.packer.io/intro/getting-started/install.html) - At least version 1.6.0 for bridge mode support
+* The VMware ESXi installation ISO must be downloaded manually. You can download it [here.](https://www.vmware.com/go/get-free-esxi) Has been tested on ESXi 6.7 and 7.0.
 
 ## Requirements (to deploy the image)
 
@@ -18,6 +17,13 @@
 
 ## Customizing the Image
 The deployment image may be customized by modifying packer-maas/vmware-esxi/http/vmware-esxi-ks.cfg see Installation and Upgrade Scripts in the [VMware ESXi installation and Setup manual](https://docs.vmware.com/en/VMware-vSphere/6.7/vsphere-esxi-67-installation-setup-guide.pdf) for more information.
+
+## Add an ACL for bridge
+Ensure you have a file located at /etc/qemu/bridge.conf that contains:
+```
+allow virbr0
+```
+This will allow packer to utilize a vmxnet3 driver on the qemu bridge.
 
 ## Building an image
 Your current working directory must be in packer-maas/vmware-esxi, where this file is located. Once in packer-maas/vmware-esxi you can generate an image with:

--- a/vmware-esxi/vmware-esxi.json
+++ b/vmware-esxi/vmware-esxi.json
@@ -7,7 +7,7 @@
             "type": "qemu",
             "communicator": "none",
             "iso_url": "{{user `vmware_esxi_iso_path`}}",
-            "iso_checksum_type": "none",
+            "iso_checksum": "none",
             "boot_command": [
                 "<enter><wait>",
                 "<leftShift>O",
@@ -20,7 +20,8 @@
             "memory": 4096,
             "http_directory": "http",
             "format": "raw",
-            "net_device": "e1000",
+            "net_bridge": "virbr0",
+            "net_device": "vmxnet3",
             "qemuargs": [
                 [ "-cpu", "host" ],
                 [ "-smp", "2,sockets=2,cores=1,threads=1" ]


### PR DESCRIPTION
e1000 support was dropped from ESXi 7 so this switches to vmxnet3
and uses the bridge support introduced in Packer 1.6.0 for all
versions.

Fixes: https://github.com/canonical/packer-maas/issues/1