### PR TITLE
Couple of changes to fix EFI enabled systems on centos8

### DIFF
--- a/centos8/http/centos8.ks
+++ b/centos8/http/centos8.ks
@@ -34,6 +34,8 @@ done
 
 rm -f /etc/sysconfig/network-scripts/ifcfg-[^lo]*
 
+sed -i -e 's/^\(GRUB_ENABLE_BLSCFG=\).*/\1false/g' /etc/default/grub
+
 dnf clean all
 %end
 
@@ -47,6 +49,7 @@ python3-oauthlib
 rsync
 tar
 grub2-efi-x64
+grub2-efi-x64-modules
 efibootmgr
 shim-x64
 dosfstools


### PR DESCRIPTION
* Added the grub2-efi-x64-modules, as this is typically required in order to run
  grub2-install on EFI enabled machines.
* We need to disable BLSCFG in order for grub2-mkconfig to successfully add all
  the menuentries in grub.

The extra package helps with the following error that we have seen with several people

```
Stderr: grub2-install: error: /usr/lib/grub/x86_64-efi/modinfo.sh doesn't exist. Please specify --target or --directory.
```