### PR TITLE
grub2 efi x64 modules are required in base image

### DIFF
--- a/centos8/http/centos8.ks
+++ b/centos8/http/centos8.ks
@@ -54,6 +54,7 @@ python3-oauthlib
 rsync
 tar
 grub2-efi-x64
+grub2-efi-x64-modules
 efibootmgr
 shim-x64
 dosfstools


### PR DESCRIPTION
While building some centos8 images last week I ran into some problems during deployment in maas and found that the following package is required in order to install to a EFI bare metal machine. 