### PR TITLE
Add megaraid_sas support to Centos8 image

### DIFF
--- a/centos7/README.md
+++ b/centos7/README.md
@@ -17,6 +17,20 @@ The Packer template in this directory creates a CentOS 7 AMD64 image for use wit
 ## Customizing the Image
 The deployment image may be customized by modifying http/centos7.ks. See the [CentOS kickstart documentation](https://docs.centos.org/en-US/centos/install-guide/Kickstart2/) for more information.
 
+## Dell RAID Support
+Support for older Dell RAID cards can be added by downloading the appropriate driver from [Dell's website](https://www.dell.com/support/search/en-us#q=Red%20Hat%20Enterprise%20Linux%207%20Driver%20for%20Dell%20PERC%20version&sort=relevancy&numberOfResults=100&f:langFacet=[en])
+
+* Un-archive the tar.gz file
+* Unzip the iso file
+* Place the iso file into the ~/http directory
+* Then modify the ~/centos7.json file as such:
+
+```
+                "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos7.ks ",
++                "inst.dd=http://{{ .HTTPIP }}:{{ .HTTPPort }}/megaraid_sas-$VERSION.x86_64.iso ",
+                "console=ttyS0 inst.cmdline",
+```
+
 ## Building the image using a proxy
 The Packer template downloads the CentOS
 net installer from the Internet. To tell Packer to use a proxy set the

--- a/centos8/README.md
+++ b/centos8/README.md
@@ -21,6 +21,15 @@ The default username is cloud-user
 ## Customizing the Image
 The deployment image may be customized by modifying http/centos8.ks. See the [CentOS kickstart documentation](https://docs.centos.org/en-US/centos/install-guide/Kickstart2/) for more information.
 
+## Dell RAID Support
+Support for older Dell RAID cards can be added by modifying the ~/centos8.json file as such:
+
+```
+                "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos8.ks ",
++                "inst.dd=https://elrepo.org/linux/dud/el8/x86_64/dd-megaraid_sas-07.714.04.00-1.el8_3.elrepo.iso ",
+                "console=ttyS0 inst.cmdline",
+```
+
 ## Building the image using a proxy
 The Packer template downloads the CentOS net installer from the Internet. To
 tell Packer to use a proxy set the HTTP_PROXY environment variable to your proxy

--- a/centos8/centos8.json
+++ b/centos8/centos8.json
@@ -13,6 +13,7 @@
             "boot_command": [
                 "<up><tab> ",
                 "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos8.ks ",
+                "inst.dd=https://elrepo.org/linux/dud/el8/x86_64/dd-megaraid_sas-07.714.04.00-1.el8_3.elrepo.iso ",
                 "console=ttyS0 inst.cmdline",
                 "<enter>"
             ],


### PR DESCRIPTION
I really struggled to get Centos to install on my Dell servers in my lab. Apparently, out of the box, Centos 7 and Centos 8 do not have drivers for older RAID cards installed, which prevents them from being able to discover the RAID provided virtual disks so that the operating system can complete its initial boot from MAAS.

I was able to get Centos8 to work by including the DUD iso noted below in the packer json configuration file. I also needed to increase the shutdown_timeout to 120m, but I figure that doesn't actually need to change in the default templates provided by this repository.

Even if this Pull Request is rejected, I think it'd be a good idea to update the documentation that this is a possible thing to do, because I had to spend several days rolling through obscure blog entries to find this solution.

**Commit Comments**
```
- EL8 based distros no longer support older RAID cards from Dell.
- Adding this line to the json installs needed drivers to get Centos8 to install on an R610, R815, and R620.
- This line will need to be updated for newer versions of Centos8, since each DUD is built for a specific starting kernel.
- Ref: https://fatmin.com/2019/11/23/installing-rhel-8-1-on-dell-r710-r610-with-h700-raid-controller/
```