### PR TITLE
Add initial support for AlmaLinux 8.3

### DIFF
--- a/almalinux8/README.md
+++ b/almalinux8/README.md
@@ -1,0 +1,55 @@
+# AlmaLinux 8 Packer Template for MAAS
+
+## Introduction
+The Packer template in this directory creates an AlmaLinux 8 AMD64 image for use
+with MAAS.
+
+## Prerequisites (to create the image)
+
+* A machine running Ubuntu 18.04+ with the ability to run KVM virtual machines.
+* qemu-utils
+* [Packer.](https://www.packer.io/intro/getting-started/install.html)
+
+## Requirements (to deploy the image)
+
+* [MAAS](https://maas.io) 2.3+, [MAAS](https://maas.io) 2.7+ recommended
+* [Curtin](https://launchpad.net/curtin) 19.3-792+
+
+## Default user
+The default username is cloud-user
+
+## Customizing the Image
+The deployment image may be customized by modifying http/almalinux8.ks. See the [CentOS kickstart documentation](https://docs.centos.org/en-US/centos/install-guide/Kickstart2/) for more information.
+
+## Building the image using a proxy
+The Packer template downloads the AlmaLinux net installer from the Internet. To
+tell Packer to use a proxy set the HTTP_PROXY environment variable to your proxy
+server. Alternatively you may redefine iso_url to a local file, set
+iso_checksum_type to none to disable checksuming, and remove iso_checksum_url.
+
+To use a proxy during the installation add the --proxy=$HTTP_PROXY flag to every
+line starting with url or repo in http/centos8.ks. Alternatively you may set the
+--mirrorlist values to a local mirror.
+
+## Building an image
+Your current working directory must be in packer-maas/almalinux8, where this file
+is located. Once in packer-maas/centos8 you can generate an image with:
+
+```
+$ sudo PACKER_LOG=1 packer build almalinux8.json
+```
+
+Note: almalinux8.json is configured to run Packer in headless mode. Only Packer
+output will be seen. If you wish to see the installation output connect to the
+VNC port given in the Packer output or change the value of headless to false in
+almalinux8.json.
+
+Installation is non-interactive.
+
+## Uploading an image to MAAS
+```
+$ maas $PROFILE boot-resources create name='almalinux/8-custom' title='AlmaLinux 8 Custom' architecture='amd64/generic' filetype='tgz' content@=almalinux8.tar.gz
+```
+
+## Default Username
+The default username is ```cloud-user```

--- a/almalinux8/almalinux8.json
+++ b/almalinux8/almalinux8.json
@@ -1,0 +1,41 @@
+{
+    "variables":
+        {
+            "almalinux8_iso_url": "https://repo.almalinux.org/almalinux/8/isos/x86_64/AlmaLinux-8.3-x86_64-boot.iso",
+            "almalinux8_sha256sum_url": "https://repo.almalinux.org/almalinux/8/isos/x86_64/CHECKSUM"
+        },
+    "builders": [
+        {
+            "type": "qemu",
+            "communicator": "none",
+            "iso_url": "{{user `almalinux8_iso_url`}}",
+            "iso_checksum": "file:{{user `almalinux8_sha256sum_url`}}",
+            "boot_command": [
+                "<up><tab> ",
+                "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux8.ks ",
+                "console=ttyS0 inst.cmdline",
+                "<enter>"
+            ],
+            "boot_wait": "3s",
+            "disk_size": "4G",
+            "headless": true,
+            "memory": 2048,
+            "http_directory": "http",
+            "qemuargs": [
+                [ "-serial", "stdio" ]
+            ],
+            "shutdown_timeout": "1h"
+        }
+    ],
+    "post-processors": [
+        {
+            "type": "shell-local",
+            "inline_shebang": "/bin/bash -e",
+            "inline": [
+                "source ../scripts/setup-nbd",
+                "OUTPUT=${OUTPUT:-almalinux8.tar.gz}",
+                "source ../scripts/tar-root"
+            ]
+        }
+    ]
+}

--- a/almalinux8/http/almalinux8.ks
+++ b/almalinux8/http/almalinux8.ks
@@ -1,0 +1,70 @@
+url --url="http://mirror.cloudpropeller.com/almalinux/8/BaseOS/x86_64/os/"
+poweroff
+firewall --enabled --service=ssh
+firstboot --disable
+ignoredisk --only-use=vda
+lang en_US.UTF-8
+keyboard us
+network --device eth0 --bootproto=dhcp
+firewall --enabled --service=ssh
+selinux --enforcing
+timezone UTC --isUtc
+bootloader --location=mbr --driveorder="vda" --timeout=1
+rootpw --plaintext password
+
+repo --name="AppStream" --baseurl="https://mirror.cloudpropeller.com/almalinux/8/AppStream/x86_64/os"
+repo --name="Extras" --baseurl="https://mirror.cloudpropeller.com/almalinux/8/extras/x86_64/os"
+
+zerombr
+clearpart --all --initlabel
+part / --size=1 --grow --asprimary --fstype=ext4
+
+%post --erroronfail
+# workaround anaconda requirements and clear root password
+passwd -d root
+passwd -l root
+
+# Clean up install config not applicable to deployed environments.
+for f in resolv.conf fstab; do
+    rm -f /etc/$f
+    touch /etc/$f
+    chown root:root /etc/$f
+    chmod 644 /etc/$f
+done
+
+rm -f /etc/sysconfig/network-scripts/ifcfg-[^lo]*
+
+# Kickstart copies install boot options. Serial is turned on for logging with
+# Packer which disables console output. Disable it so console output is shown
+# during deployments
+sed -i 's/^GRUB_TERMINAL=.*/GRUB_TERMINAL_OUTPUT="console"/g' /etc/default/grub
+sed -i '/GRUB_SERIAL_COMMAND="serial"/d' /etc/default/grub
+sed -ri 's/(GRUB_CMDLINE_LINUX=".*)\s+console=ttyS0(.*")/\1\2/' /etc/default/grub
+
+dnf clean all
+%end
+
+%packages
+@core
+bash-completion
+cloud-init
+# cloud-init only requires python3-oauthlib with MAAS. As such upstream
+# removed this dependency.
+python3-oauthlib
+rsync
+tar
+# grub2-efi-x64 ships grub signed for UEFI secure boot. If grub2-efi-x64-modules
+# is installed grub will be generated on deployment and unsigned which breaks
+# UEFI secure boot.
+grub2-efi-x64
+efibootmgr
+shim-x64
+dosfstools
+lvm2
+mdadm
+device-mapper-multipath
+iscsi-initiator-utils
+-plymouth
+# Remove Intel wireless firmware
+-i*-firmware
+%end


### PR DESCRIPTION
Adds initial support for building images for AlmaLinux

Requires updates to curtin upstream in order for distro
detection, see:

https://bugs.launchpad.net/curtin/+bug/1922970