### PR TITLE
Add support for Rocky 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ ubuntu/*.iso
 ubuntu/packages/*.deb
 ubuntu/packages/*.bin
 ubuntu/packages/*.tar.gz
+.vscode

--- a/rocky8/Makefile
+++ b/rocky8/Makefile
@@ -1,0 +1,12 @@
+PACKER ?= packer
+
+.PHONY: all clean
+
+all: rocky8.tar.gz
+
+rocky8.tar.gz: clean
+	sudo PACKER_LOG=1 ${PACKER} build rocky8.json
+	reset
+
+clean:
+	sudo ${RM} -rf output-qemu rocky8.tar.gz

--- a/rocky8/README.md
+++ b/rocky8/README.md
@@ -12,7 +12,7 @@ The Packer template in this directory creates a Rocky 8 AMD64 image for use with
 ## Requirements to deploy the image
 
 * [MAAS](https://maas.io) 3.2+
-* [Curtin](https://launchpad.net/curtin) with [this bug](https://bugs.launchpad.net/curtin/+bug/1955671) resolved. In the meantime, you can manually change distro.py to deploy Rocky.
+* [Curtin](https://launchpad.net/curtin) 22.1. If you have a MAAS with an earlier Curtin version, you can [patch](https://code.launchpad.net/~xnox/curtin/+git/curtin/+merge/415604) distro.py to deploy Rocky.
 
 ## Customizing the image
 You can customize the deployment image by modifying http/rocky.ks. See the [RHEL kickstart documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#part-or-partition_kickstart-commands-for-handling-storage) for more information.

--- a/rocky8/README.md
+++ b/rocky8/README.md
@@ -1,0 +1,51 @@
+# Rocky 8 Packer template for MAAS
+
+## Introduction
+The Packer template in this directory creates a Rocky 8 AMD64 image for use with MAAS.
+
+## Prerequisites to create the image
+
+* A machine running Ubuntu 18.04+ with the ability to run KVM virtual machines.
+* qemu-utils
+* [Packer.](https://www.packer.io/intro/getting-started/install.html)
+
+## Requirements to deploy the image
+
+* [MAAS](https://maas.io) 3.2+
+* [Curtin](https://launchpad.net/curtin) with [this bug](https://bugs.launchpad.net/curtin/+bug/1955671) resolved. In the meantime, you can manually change distro.py to deploy Rocky.
+
+## Customizing the image
+You can customize the deployment image by modifying http/rocky.ks. See the [RHEL kickstart documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#part-or-partition_kickstart-commands-for-handling-storage) for more information.
+
+## Building the image using a proxy
+The Packer template downloads the Rocky ISO image from the Internet. You can tell Packer to use a proxy by setting the HTTP_PROXY environment variable to point to your proxy server. You can also  redefine rocky_iso_url to a local file. If you want to skip the base image integrity check, set iso_checksum_type to none and remove iso_checksum.
+
+You can add the --proxy=$HTTP_PROXY flag to every line starting with url in http/rocky.ks to use a proxy during installation.
+
+## Building an image
+You can build the image using the Makefile:
+
+```
+$ make
+```
+
+You can also manually run packer. Set your current working directory to packer-maas/rocky8, where this file resides, and generate an image with:
+
+```
+$ sudo PACKER_LOG=1 packer build rocky8.json
+```
+The installation runs in a non-interactive mode.
+
+Note: rocky8.json runs Packer in headless mode, with the serial port output from qemu redirected to stdio to give feedback on image creation process. If you wish to see more, change the value of `headless` to `false` in rocky8.json, remove `[ "-serial", "stdio" ]` from `qemuargs` section and select `View`, then `serial0` in the qemu window that appears during build. This lets you watch progress of the image build script. Press `ctrl-b 2` to switch to shell to explore more, and `ctrl-b 1` to go back to log view.
+
+## Uploading an image to MAAS
+```
+$ maas $PROFILE boot-resources create name='custom/rocky8' title='Rocky 8 Custom' architecture='amd64/generic' base_image='rhel/8' filetype='tgz' content@=rocky8.tar.gz
+```
+
+## Default username
+MAAS uses cloud-init to create ```cloud-user``` account using the ssh keys configured for the MAAS admin user (e.g. imported from Launchpad). Log in to the machine:
+```
+ssh -i ~/.ssh/<your_identity_file> cloud-user@<machine-ip-address>
+```
+Next to that, the kickstart script creates an account with both username and password set to  ```rocky```. Note that the default sshd configuration in Rocky 8 disallows password-based authentication when logging in via ssh, so trying `ssh rocky@<machine-ip-address>` will fail. Password-based authentication can be enabled by having `PasswordAuthentication yes` in /etc/ssh/sshd_config after logging in with ```cloud-user```. Perhaps there is a way to make that change using kickstart script, but it is not obvious as ```anaconda```, the installer, makes its own changes to sshd_config file during installation. If you know how to do this, a PR is welcome.

--- a/rocky8/http/rocky.ks
+++ b/rocky8/http/rocky.ks
@@ -1,0 +1,113 @@
+url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
+url --mirrorlist="http://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=BaseOS-8"
+repo --name="AppStream" --mirrorlist="http://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=rocky-AppStream-8.6"
+repo --name="Extras" --mirrorlist="http://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=rocky-extras-8.6"
+
+eula --agreed
+
+# Turn off after installation
+poweroff
+
+# Do not start the Inital Setup app
+firstboot --disable
+
+# System language, keyboard and timezone
+lang en_US.UTF-8
+keyboard us
+timezone UTC --isUtc
+
+# Set the first NIC to acquire IPv4 address via DHCP
+network --device eth0 --bootproto=dhcp
+# Enable firewal, let SSH through
+firewall --enabled --service=ssh
+# Enable SELinux with default enforcing policy
+selinux --enforcing
+
+# Do not set up XX Window System
+skipx
+
+# Initial disk setup
+# Use the first paravirtualized disk
+ignoredisk --only-use=vda
+# Place the bootloader on the Master Boot Record
+bootloader --location=mbr --driveorder="vda" --timeout=1
+# Wipe invalid partition tables
+zerombr
+# Erase all partitions and assign default labels
+clearpart --all --initlabel
+# Initialize the primary root partition with ext4 filesystem
+part / --size=1 --grow --asprimary --fstype=ext4
+
+# Set root password
+rootpw --plaintext password
+
+# Add a user named packer
+user --groups=wheel --name=rocky --password=rocky --plaintext --gecos="rocky"
+
+%post --erroronfail
+# workaround anaconda requirements and clear root password
+passwd -d root
+passwd -l root
+
+# Clean up install config not applicable to deployed environments.
+for f in resolv.conf fstab; do
+    rm -f /etc/$f
+    touch /etc/$f
+    chown root:root /etc/$f
+    chmod 644 /etc/$f
+done
+
+rm -f /etc/sysconfig/network-scripts/ifcfg-[^lo]*
+
+# Kickstart copies install boot options. Serial is turned on for logging with
+# Packer which disables console output. Disable it so console output is shown
+# during deployments
+sed -i 's/^GRUB_TERMINAL=.*/GRUB_TERMINAL_OUTPUT="console"/g' /etc/default/grub
+sed -i '/GRUB_SERIAL_COMMAND="serial"/d' /etc/default/grub
+sed -ri 's/(GRUB_CMDLINE_LINUX=".*)\s+console=ttyS0(.*")/\1\2/' /etc/default/grub
+
+yum clean all
+
+# Passwordless sudo for the user 'rocky'
+echo "rocky ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/rocky
+chmod 440 /etc/sudoers.d/rocky
+
+#---- Optional - Install your SSH key ----
+# mkdir -m0700 /home/rocky/.ssh/
+#
+# cat <<EOF >/home/rocky/.ssh/authorized_keys
+# ssh-rsa <your_public_key_here> you@your.domain
+# EOF
+#
+### set permissions
+# chmod 0600 /home/rocky/.ssh/authorized_keys
+#
+#### fix up selinux context
+# restorecon -R /home/rocky/.ssh/
+
+%end
+
+%packages
+@Core
+bash-completion
+cloud-init
+cloud-utils-growpart
+rsync
+tar
+patch
+yum-utils
+grub2-efi-x64
+shim-x64
+grub2-efi-x64-modules
+efibootmgr
+dosfstools
+lvm2
+mdadm
+device-mapper-multipath
+iscsi-initiator-utils
+-plymouth
+# Remove ALSA firmware
+-a*-firmware
+# Remove Intel wireless firmware
+-i*-firmware
+%end

--- a/rocky8/rocky8.json
+++ b/rocky8/rocky8.json
@@ -1,0 +1,42 @@
+{
+    "variables":
+        {
+            "rocky_iso_url": "https://download.rockylinux.org/pub/rocky/8.6/isos/x86_64/Rocky-8.6-x86_64-boot.iso",
+            "rocky_sha256sum_url": "https://download.rockylinux.org/pub/rocky/8.6/isos/x86_64/CHECKSUM"
+        },
+    "builders": [
+        {
+            "type": "qemu",
+            "communicator": "none",
+            "iso_url": "{{user `rocky_iso_url`}}",
+            "iso_checksum": "file:{{user `rocky_sha256sum_url`}}",
+            "boot_command": [
+                "<up><tab> ",
+                "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/rocky.ks ",
+                "console=ttyS0 inst.cmdline",
+                "<enter>"
+            ],
+            "boot_wait": "3s",
+            "disk_size": "4G",
+            "headless": true,
+            "memory": 2048,
+            "http_directory": "http",
+            "qemuargs": [
+                [ "-serial", "stdio" ]
+            ],
+
+            "shutdown_timeout": "1h"
+        }
+    ],
+    "post-processors": [
+        {
+            "type": "shell-local",
+            "inline_shebang": "/bin/bash -e",
+            "inline": [
+                "source ../scripts/setup-nbd",
+                "OUTPUT=${OUTPUT:-rocky8.tar.gz}",
+                "source ../scripts/tar-root"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds support for Rocky 8. Note that it requires a patched Curtin version to work - this is clearly indicated in the readme file. When [this Curtin issue](https://bugs.launchpad.net/curtin/+bug/1955671) is resolved, both the Curtin and MAAS versions in the readme file should be updated.