### PR TITLE
ci: add github action to run packer fmt

### DIFF
--- a/.github/workflows/packer.yaml
+++ b/.github/workflows/packer.yaml
@@ -1,0 +1,20 @@
+name: Packer
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    # Run checks on reopened draft PRs to support triggering PR checks on draft PRs that were opened
+    # by other workflows.
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  packer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hashicorp/packer-github-actions@master
+        with:
+          command: fmt
+          arguments: -check -diff
+          target: .


### PR DESCRIPTION
This PR adds a small action to run `packer fmt` to do template formatting sanity checks.