### PR TITLE
Updated machine sizing, removed extra whitespace

### DIFF
--- a/ubuntu/ubuntu-flat.pkr.hcl
+++ b/ubuntu/ubuntu-flat.pkr.hcl
@@ -8,14 +8,14 @@ source "qemu" "flat" {
   boot_command    = ["<wait>e<wait5>", "<down><wait><down><wait><down><wait2><end><wait5>", "<bs><bs><bs><bs><wait>autoinstall ---<wait><f10>"]
   boot_wait       = "2s"
   cpus            = 2
-  disk_size       = "4G"
+  disk_size       = "8G"
   format          = "raw"
   headless        = var.headless
   http_directory  = var.http_directory
   iso_checksum    = "file:http://releases.ubuntu.com/jammy/SHA256SUMS"
   iso_target_path = "packer_cache/ubuntu.iso"
   iso_url         = "https://releases.ubuntu.com/jammy/ubuntu-22.04.1-live-server-amd64.iso"
-  memory          = 1024
+  memory          = 2048
   qemuargs = [
     ["-vga", "qxl"],
     ["-device", "virtio-blk-pci,drive=drive0,bootindex=0"],

--- a/ubuntu/ubuntu-lvm.pkr.hcl
+++ b/ubuntu/ubuntu-lvm.pkr.hcl
@@ -2,14 +2,14 @@ source "qemu" "lvm" {
   boot_command    = ["<wait>e<wait5>", "<down><wait><down><wait><down><wait2><end><wait5>", "<bs><bs><bs><bs><wait>autoinstall ---<wait><f10>"]
   boot_wait       = "2s"
   cpus            = 2
-  disk_size       = "4G"
+  disk_size       = "8G"
   format          = "raw"
   headless        = var.headless
   http_directory  = var.http_directory
   iso_checksum    = "file:http://releases.ubuntu.com/jammy/SHA256SUMS"
   iso_target_path = "packer_cache/ubuntu.iso"
   iso_url         = "https://releases.ubuntu.com/jammy/ubuntu-22.04.1-live-server-amd64.iso"
-  memory          = 1024
+  memory          = 2048
   qemuargs = [
     ["-vga", "qxl"],
     ["-device", "virtio-blk-pci,drive=drive0,bootindex=0"],

--- a/ubuntu/user-data-cloudimg
+++ b/ubuntu/user-data-cloudimg
@@ -10,7 +10,6 @@ preserve_hostname: true
 runcmd:
   - sed -i -e '/^[#]*PermitRootLogin/s/^.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
   - systemctl restart ssh
-
 bootcmd:
   - mkdir /run/packer_backup
   - mkdir /run/packer_backup/etc

--- a/ubuntu/user-data-flat
+++ b/ubuntu/user-data-flat
@@ -10,7 +10,6 @@ autoinstall:
     variant: us
   ssh:
     install-server: true
-
   storage:
     grub:
       update_nvram: true
@@ -18,9 +17,7 @@ autoinstall:
       size: 0
     layout:
       name: direct
-
   late-commands:
     - echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /target/etc/sudoers.d/ubuntu
-
   package_update: true
   package_upgrade: true

--- a/ubuntu/user-data-lvm
+++ b/ubuntu/user-data-lvm
@@ -10,7 +10,6 @@ autoinstall:
     variant: us
   ssh:
     install-server: true
-
   storage:
     grub:
       update_nvram: true
@@ -18,9 +17,7 @@ autoinstall:
       size: 0
     layout:
       name: lvm
-
   late-commands:
     - echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /target/etc/sudoers.d/ubuntu
-
   package_update: true
   package_upgrade: true


### PR DESCRIPTION
I updated the machine sizing for the ubuntu flat and lvm templates, as I found I was unable to reliably build images with 1024MB of RAM and 4GB of disk. I found I needed to bump both to 2048 MB of RAM and 8GB of disk to get the machines to reliably build and not crash with a subiquity error. I also removed extra white space in the autoinstall templates that may trip up subiquity.

