### PR TITLE
fix(ubuntu): mount seeds-flat iso in read-only mode

### DIFF
--- a/ubuntu/ubuntu-flat.pkr.hcl
+++ b/ubuntu/ubuntu-flat.pkr.hcl
@@ -24,7 +24,7 @@ source "qemu" "flat" {
     ["-drive", "if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE.fd"],
     ["-drive", "if=pflash,format=raw,file=OVMF_VARS.fd"],
     ["-drive", "file=output-flat/packer-flat,if=none,id=drive0,cache=writeback,discard=ignore,format=raw"],
-    ["-drive", "file=seeds-flat.iso,format=raw,cache=none,if=none,id=drive1,readonly"],
+    ["-drive", "file=seeds-flat.iso,format=raw,cache=none,if=none,id=drive1,readonly=on"],
     ["-drive", "file=packer_cache/ubuntu.iso,if=none,id=cdrom0,media=cdrom"]
   ]
   shutdown_command       = "sudo -S shutdown -P now"

--- a/ubuntu/ubuntu-lvm.pkr.hcl
+++ b/ubuntu/ubuntu-lvm.pkr.hcl
@@ -18,7 +18,7 @@ source "qemu" "lvm" {
     ["-drive", "if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE.fd"],
     ["-drive", "if=pflash,format=raw,file=OVMF_VARS.fd"],
     ["-drive", "file=output-lvm/packer-lvm,if=none,id=drive0,cache=writeback,discard=ignore,format=raw"],
-    ["-drive", "file=seeds-lvm.iso,format=raw,cache=none,if=none,id=drive1,readonly"],
+    ["-drive", "file=seeds-lvm.iso,format=raw,cache=none,if=none,id=drive1,readonly=on"],
     ["-drive", "file=packer_cache/ubuntu.iso,if=none,id=cdrom0,media=cdrom"]
   ]
   shutdown_command       = "sudo -S shutdown -P now"


### PR DESCRIPTION
Newer versions of QEMU require ISO images mounted in read-write mode to be 4K-aligned and fail otherwise. However, this requirement does not apply to read-only mounted ISOs. Since it seems like we don't need to write anything to that file, making it read-only looks like a viable fix for #79 