### PR TITLE
fix(rocky): Update packer to download Rocky 9.1 / 8.7

### DIFF
--- a/rocky8/http/rocky.ks
+++ b/rocky8/http/rocky.ks
@@ -1,7 +1,7 @@
 url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
 url --mirrorlist="http://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=BaseOS-8"
-repo --name="AppStream" --mirrorlist="http://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=rocky-AppStream-8.6"
-repo --name="Extras" --mirrorlist="http://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=rocky-extras-8.6"
+repo --name="AppStream" --mirrorlist="http://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=rocky-AppStream-8.7"
+repo --name="Extras" --mirrorlist="http://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=rocky-extras-8.7"
 
 eula --agreed
 

--- a/rocky8/rocky8.pkr.hcl
+++ b/rocky8/rocky8.pkr.hcl
@@ -16,7 +16,7 @@ variable "filename" {
 
 variable "rocky_iso_url" {
   type    = string
-  default = "http://download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.6-x86_64-boot.iso"
+  default = "http://download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.7-x86_64-boot.iso"
 }
 
 variable "rocky_sha256sum_url" {

--- a/rocky9/http/rocky.ks
+++ b/rocky9/http/rocky.ks
@@ -1,7 +1,7 @@
 url --url="https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/"
 url --mirrorlist="http://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=BaseOS-9"
-repo --name="AppStream" --mirrorlist="https://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=rocky-AppStream-9.0"
-repo --name="Extras" --mirrorlist="http://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=rocky-extras-9.0"
+repo --name="AppStream" --mirrorlist="https://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=rocky-AppStream-9.1"
+repo --name="Extras" --mirrorlist="http://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=rocky-extras-9.1"
 
 eula --agreed
 

--- a/rocky9/rocky9.pkr.hcl
+++ b/rocky9/rocky9.pkr.hcl
@@ -22,7 +22,7 @@ variable "headless" {
 
 variable "rocky_iso_url" {
   type    = string
-  default = "https://download.rockylinux.org/pub/rocky/9/isos/x86_64/Rocky-9.0-x86_64-boot.iso"
+  default = "https://download.rockylinux.org/pub/rocky/9/isos/x86_64/Rocky-9.1-x86_64-boot.iso"
 }
 
 variable "rocky_sha256sum_url" {


### PR DESCRIPTION
In its current state, Rocky does not work.
Both downloads point to old version that are no longer available.  
Also updated the kickstart file otherwise it will hang.

 - Updated `/rocky9/rocky9.pkr.hcl`
 - Updated `/rocky9/http/rocky.ks`
 - Updated `/rocky8/rocky8.pkr.hcl`
 - Updated `/rocky8/http/rocky.ks`

This fixes https://github.com/canonical/packer-maas/issues/85