### PR TITLE
chore(dependencies): updated hashicorp qemu plugin on all packer images

### DIFF
--- a/centos6/centos6.pkr.hcl
+++ b/centos6/centos6.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.8.0"
   required_plugins {
     qemu = {
       version = "~> 1.0"

--- a/centos7/centos7.pkr.hcl
+++ b/centos7/centos7.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.8.0"
   required_plugins {
     qemu = {
       version = "~> 1.0"

--- a/centos8-stream/centos8-stream.pkr.hcl
+++ b/centos8-stream/centos8-stream.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.8.0"
   required_plugins {
     qemu = {
       version = "~> 1.0"

--- a/centos8/centos8.pkr.hcl
+++ b/centos8/centos8.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.8.0"
   required_plugins {
     qemu = {
       version = "~> 1.0"

--- a/rhel7/rhel7.pkr.hcl
+++ b/rhel7/rhel7.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.8.0"
   required_plugins {
     qemu = {
       version = "~> 1.0"

--- a/rhel8/rhel8.pkr.hcl
+++ b/rhel8/rhel8.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.8.0"
   required_plugins {
     qemu = {
       version = "~> 1.0"

--- a/rhel9/rhel9.pkr.hcl
+++ b/rhel9/rhel9.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.8.0"
   required_plugins {
     qemu = {
       version = "~> 1.0"

--- a/rocky8/rocky8.pkr.hcl
+++ b/rocky8/rocky8.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.8.0"
   required_plugins {
     qemu = {
       version = "~> 1.0"

--- a/rocky9/rocky9.pkr.hcl
+++ b/rocky9/rocky9.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.8.0"
   required_plugins {
     qemu = {
       version = "~> 1.0"

--- a/sles12/sles.pkr.hcl
+++ b/sles12/sles.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.8.0"
   required_plugins {
     qemu = {
       version = "~> 1.0"

--- a/sles15/sles.pkr.hcl
+++ b/sles15/sles.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.8.0"
   required_plugins {
     qemu = {
       version = "~> 1.0"

--- a/ubuntu/variables.pkr.hcl
+++ b/ubuntu/variables.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.8.0"
   required_plugins {
     qemu = {
       version = "~> 1.0"

--- a/vmware-esxi/vmware-esxi.pkr.hcl
+++ b/vmware-esxi/vmware-esxi.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.8.0"
   required_plugins {
     qemu = {
       version = "~> 1.0"


### PR DESCRIPTION
Updated  HashiCorp `qemu` plugin to `1.8.0`

Release here https://github.com/hashicorp/packer-plugin-qemu/releases/tag/v1.0.8