### PR TITLE
update iso_url to fix checksum error see #97

### DIFF
--- a/ubuntu/ubuntu-flat.pkr.hcl
+++ b/ubuntu/ubuntu-flat.pkr.hcl
@@ -12,9 +12,9 @@ source "qemu" "flat" {
   format          = "raw"
   headless        = var.headless
   http_directory  = var.http_directory
-  iso_checksum    = "file:http://releases.ubuntu.com/jammy/SHA256SUMS"
+  iso_checksum    = "sha256:10f19c5b2b8d6db711582e0e27f5116296c34fe4b313ba45f9b201a5007056cb"
   iso_target_path = "packer_cache/ubuntu.iso"
-  iso_url         = "https://releases.ubuntu.com/jammy/ubuntu-22.04.2-live-server-amd64.iso"
+  iso_url         = "https://old-releases.ubuntu.com/releases/22.04.1/ubuntu-22.04.1-live-server-amd64.iso"
   memory          = 2048
   qemuargs = [
     ["-vga", "qxl"],

--- a/ubuntu/ubuntu-flat.pkr.hcl
+++ b/ubuntu/ubuntu-flat.pkr.hcl
@@ -14,7 +14,7 @@ source "qemu" "flat" {
   http_directory  = var.http_directory
   iso_checksum    = "file:http://releases.ubuntu.com/jammy/SHA256SUMS"
   iso_target_path = "packer_cache/ubuntu.iso"
-  iso_url         = "https://releases.ubuntu.com/jammy/ubuntu-22.04.1-live-server-amd64.iso"
+  iso_url         = "https://releases.ubuntu.com/jammy/ubuntu-22.04.2-live-server-amd64.iso"
   memory          = 2048
   qemuargs = [
     ["-vga", "qxl"],

--- a/ubuntu/ubuntu-lvm.pkr.hcl
+++ b/ubuntu/ubuntu-lvm.pkr.hcl
@@ -8,7 +8,7 @@ source "qemu" "lvm" {
   http_directory  = var.http_directory
   iso_checksum    = "file:http://releases.ubuntu.com/jammy/SHA256SUMS"
   iso_target_path = "packer_cache/ubuntu.iso"
-  iso_url         = "https://releases.ubuntu.com/jammy/ubuntu-22.04.1-live-server-amd64.iso"
+  iso_url         = "https://releases.ubuntu.com/jammy/ubuntu-22.04.2-live-server-amd64.iso"
   memory          = 2048
   qemuargs = [
     ["-vga", "qxl"],

--- a/ubuntu/ubuntu-lvm.pkr.hcl
+++ b/ubuntu/ubuntu-lvm.pkr.hcl
@@ -6,9 +6,9 @@ source "qemu" "lvm" {
   format          = "raw"
   headless        = var.headless
   http_directory  = var.http_directory
-  iso_checksum    = "file:http://releases.ubuntu.com/jammy/SHA256SUMS"
+  iso_checksum    = "sha256:10f19c5b2b8d6db711582e0e27f5116296c34fe4b313ba45f9b201a5007056cb"
   iso_target_path = "packer_cache/ubuntu.iso"
-  iso_url         = "https://releases.ubuntu.com/jammy/ubuntu-22.04.2-live-server-amd64.iso"
+  iso_url         = "https://old-releases.ubuntu.com/releases/22.04.1/ubuntu-22.04.1-live-server-amd64.iso"
   memory          = 2048
   qemuargs = [
     ["-vga", "qxl"],


### PR DESCRIPTION
~~Change iso_url from 22.04.1 to 22.04.2 to fix checksum error since http://releases.ubuntu.com/jammy/SHA256SUMS now references 22.04.2~~

The build was failing with 22.04.2 so this PR updates the url and checksum for 22.04.1