### PR TITLE
rocky8: update repo and ISO download URLs

### DIFF
--- a/rocky8/http/rocky.ks
+++ b/rocky8/http/rocky.ks
@@ -1,7 +1,7 @@
 url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
 url --mirrorlist="http://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=BaseOS-8"
-repo --name="AppStream" --mirrorlist="http://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=rocky-AppStream-8.7"
-repo --name="Extras" --mirrorlist="http://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=rocky-extras-8.7"
+repo --name="AppStream" --mirrorlist="https://mirrors.rockylinux.org/mirrorlist?release=8&arch=x86_64&repo=AppStream-8"
+repo --name="Extras" --mirrorlist="https://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=extras-8"
 
 eula --agreed
 

--- a/rocky8/rocky8.pkr.hcl
+++ b/rocky8/rocky8.pkr.hcl
@@ -16,7 +16,7 @@ variable "filename" {
 
 variable "rocky_iso_url" {
   type    = string
-  default = "http://download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.7-x86_64-boot.iso"
+  default = "http://download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-x86_64-boot.iso"
 }
 
 variable "rocky_sha256sum_url" {


### PR DESCRIPTION
Enterprise Linux flavors now have version 8.8 available. The existing rocky8 files point specifically to 8.7 in the ISO download and AppSteam/Extras repo URLs.

This commit just updates the URLs to point to more generic "version 8" URLs instead of specifically version 8.7.