### PR TITLE
update ubuntu version in hcls files to match cecksums

### DIFF
--- a/ubuntu/ubuntu-flat.pkr.hcl
+++ b/ubuntu/ubuntu-flat.pkr.hcl
@@ -14,7 +14,7 @@ source "qemu" "flat" {
   http_directory  = var.http_directory
   iso_checksum    = "file:http://releases.ubuntu.com/jammy/SHA256SUMS"
   iso_target_path = "packer_cache/ubuntu.iso"
-  iso_url         = "https://releases.ubuntu.com/jammy/ubuntu-22.04.2-live-server-amd64.iso"
+  iso_url         = "https://releases.ubuntu.com/jammy/ubuntu-22.04.3-live-server-amd64.iso"
   memory          = 2048
   qemuargs = [
     ["-vga", "qxl"],

--- a/ubuntu/ubuntu-lvm.pkr.hcl
+++ b/ubuntu/ubuntu-lvm.pkr.hcl
@@ -8,7 +8,7 @@ source "qemu" "lvm" {
   http_directory  = var.http_directory
   iso_checksum    = "file:http://releases.ubuntu.com/jammy/SHA256SUMS"
   iso_target_path = "packer_cache/ubuntu.iso"
-  iso_url         = "https://releases.ubuntu.com/jammy/ubuntu-22.04.2-live-server-amd64.iso"
+  iso_url         = "https://releases.ubuntu.com/jammy/ubuntu-22.04.3-live-server-amd64.iso"
   memory          = 2048
   qemuargs = [
     ["-vga", "qxl"],


### PR DESCRIPTION
Similar to https://github.com/canonical/packer-maas/issues/97, Ubuntu version is out of sync with Checksums. 