### PR TITLE
clean the script exit status

### DIFF
--- a/vmware-esxi/post.sh
+++ b/vmware-esxi/post.sh
@@ -11,3 +11,5 @@ echo 'Unmounting image...'
 sync -f "$TMP_DIR"/boot
 fusermount -z -u "$TMP_DIR"/boot
 grep -qs "$TMP_DIR/boot " /proc/mounts && umount -f "$TMP_DIR"/boot
+
+echo 'Done'


### PR DESCRIPTION
if the `grep` command doesn't find the boot partition mounted in /proc/mounts, it skips the `umount` command (as expected) but it leaves the script result code as 'failed' (undesired side-effect)

just running a successful command solves this issue. ('exit 0' also works)

fixes #149