### PR TITLE
Fixed ESXi 7/8 build and deployment issues + README update

### DIFF
--- a/vmware-esxi/README.md
+++ b/vmware-esxi/README.md
@@ -68,6 +68,9 @@ maas $PROFILE boot-resources create \
   architecture='amd64/generic' filetype='ddgz' \
   content@=vmware-esxi.dd.gz
 ```
+## Default Credentials
+
+The default username is ```root``` and the default password is set to ```password123!```
 
 ## Known limitations
 

--- a/vmware-esxi/curtin/curtin-hooks
+++ b/vmware-esxi/curtin/curtin-hooks
@@ -30,12 +30,19 @@ from curtin.log import LOG
 from curtin.util import load_command_environment
 
 
-def exec_prog(*cmdline: str) -> None:
-    subprocess.check_call(
-        cmdline,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.STDOUT,
-    )
+def exec_prog(command):
+    try:
+        result = subprocess.run(command,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                text=True, shell=True)
+
+        if result.returncode == 0:
+            LOG.info(result.stdout)
+        else:
+            print("Error:\n", result.stderr)
+    except Exception as e:
+        print(f"Exception: {e}")
 
 
 def write_config(target, config):
@@ -67,11 +74,11 @@ def write_config(target, config):
     LOG.info("altbootbank found at %s", altbootbank_blkdev)
 
     altbootbank_mount_point = tempfile.mkdtemp(prefix="curtin-hooks-")
-    exec_prog("mount", altbootbank_blkdev, altbootbank_mount_point)
+    exec_prog(f"mount {altbootbank_blkdev} {altbootbank_mount_point}")
 
     scripts_pkg = os.path.join(os.path.dirname(__file__), "scripts.tar.xz")
     LOG.info("MAAS scripts found at %s", scripts_pkg)
-    exec_prog("tar", "xJf", scripts_pkg, "-C", altbootbank_mount_point)
+    exec_prog(f"tar xJf {scripts_pkg} -C {altbootbank_mount_point}")
     os.remove(scripts_pkg)
 
     curtin_cfg_path = os.path.join(
@@ -82,7 +89,7 @@ def write_config(target, config):
 
     LOG.info("wrote Curtin config to %s", curtin_cfg_path)
 
-    exec_prog("umount", altbootbank_mount_point)
+    exec_prog(f"umount {altbootbank_mount_point}")
 
 
 def cleanup():

--- a/vmware-esxi/requirements.txt
+++ b/vmware-esxi/requirements.txt
@@ -1,4 +1,4 @@
 ipaddr==2.2.0
-oauthlib==3.1.0
-PyYAML==5.4.1
+oauthlib==3.2.2
+PyYAML==6.0.1
 requests==2.31.0


### PR DESCRIPTION
Fixed a curtin-hook error by rewriting the exec_prog function which was preventing ESXi 7/8 deployments.
    
Updated PIP requirements.txt to prevent build errors. Fixes #127 
  
Updated README.md to include the default password.
