### PR TITLE
Resolve deployment issues with Ubuntu/Cloudimg builds + a custom kernel 

### DIFF
--- a/ubuntu/scripts/cloudimg/curtin-hooks
+++ b/ubuntu/scripts/cloudimg/curtin-hooks
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # curtin-hooks - Curtin installation hooks for Ubuntu
 #
-# Copyright (C) 2022 Canonical
+# Copyright (C) 2023 Canonical
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -21,7 +21,19 @@ import shutil
 
 from curtin.commands.curthooks import builtin_curthooks
 from curtin.config import load_command_config
-from curtin.util import load_command_environment
+from curtin.util import load_command_environment, ChrootableTarget
+from curtin.log import LOG
+from curtin.paths import target_path
+
+def run_hook_in_target(target, hook):
+    """Look for "hook" in "target" and run in a chroot"""
+    target_hook = target_path(target, '/curtin/' + hook)
+    if os.path.isfile(target_hook):
+        LOG.debug("running %s" % target_hook)
+        with ChrootableTarget(target=target) as in_chroot:
+            in_chroot.subp(['/curtin/' + hook])
+        return True
+    return False
 
 
 def configure_custom_kernel(config):
@@ -52,6 +64,7 @@ def main():
 
     config = configure_custom_kernel(config)
     builtin_curthooks(config, target, state)
+    run_hook_in_target(target, 'install-custom-kernel')
     cleanup()
 
 

--- a/ubuntu/scripts/cloudimg/register-custom-kernel.sh
+++ b/ubuntu/scripts/cloudimg/register-custom-kernel.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# install-custom-kernel.sh - Install custom kernel, if specified
+# register-custom-kernel.sh - Register a custom kernel to be installed
 #
 # Copyright (C) 2023 Canonical
 #
@@ -18,9 +18,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 export DEBIAN_FRONTEND=noninteractive
 
-if [ -f /curtin/CUSTOM_KERNEL ]; then
-        KERNEL_PKG=$(cat /curtin/CUSTOM_KERNEL)
-        echo "Installing custom kernel ${KERNEL_PKG}"
-        apt-get install -y ${KERNEL_PKG}
+if  [ -z  "${CLOUDIMG_CUSTOM_KERNEL}" ]; then
+  echo "Not installing custom kernel, since none was specified."
+  exit 0
 fi
 
+# Register the custom kernel version, so that the curtin hook knows about it.
+mkdir -p /curtin
+echo -n "${CLOUDIMG_CUSTOM_KERNEL}" > /curtin/CUSTOM_KERNEL

--- a/ubuntu/ubuntu-cloudimg.pkr.hcl
+++ b/ubuntu/ubuntu-cloudimg.pkr.hcl
@@ -94,12 +94,13 @@ build {
       "CLOUDIMG_CUSTOM_KERNEL=${var.kernel}",
       "DEBIAN_FRONTEND=noninteractive"
     ]
-    scripts = ["${path.root}/scripts/cloudimg/install-custom-kernel.sh"]
+    scripts = ["${path.root}/scripts/cloudimg/register-custom-kernel.sh"]
   }
 
   provisioner "file" {
     destination = "/tmp/"
-    sources     = ["${path.root}/scripts/cloudimg/curtin-hooks"]
+    sources     = ["${path.root}/scripts/cloudimg/curtin-hooks",
+                   "${path.root}/scripts/cloudimg/install-custom-kernel.sh"]
   }
 
   provisioner "shell" {


### PR DESCRIPTION
Ubuntu/Cloudimg: Register and then install custom
kernels in-target at deployment time.

This fixes unbootable machines due to
missing kernel image and initrd in
/boot.

Closes: #175