### PR TITLE
detect bls_boot partition

### DIFF
--- a/scripts/fuse-nbd
+++ b/scripts/fuse-nbd
@@ -32,14 +32,31 @@ sync -f "${PACKER_OUTPUT}"
 
 TMP_DIR=$(mktemp -d /tmp/packer-maas-XXXX)
 cleanup() {
-    for dev in "${TMP_DIR}"/p*/; do
+    for dev in "${TMP_DIR}"/p*/ "${TMP_DIR}"/disk/ "${TMP_DIR}"/boot/; do
         dev=${dev%*/}
-        fusermount -u -z "${dev}"
-        grep -qs "${dev} " /proc/mounts && umount -f "${dev}"
+        if [ -d "${dev}" ]; then
+            fusermount -u -z "${dev}"
+            grep -qs "${dev} " /proc/mounts && umount -f "${dev}"
+        fi
     done
     rm -rf "${TMP_DIR}"
 }
 trap cleanup EXIT
+
+function mount_disk() {
+    DEV=$1
+    mkdir -p "${DEV}"
+    nbdfuse "${DEV}" \
+        --command nbdkit -s nbd \
+        socket="${TMP_DIR}"/qemu-img.sock &
+    retries=0
+    until [ -f "${DEV}/nbd" ]; do
+        sleep 1
+        if ((++retries > 10)); then
+            return 1
+        fi
+    done
+}
 
 function mount_part() {
     PART=$1

--- a/scripts/fuse-tar-root
+++ b/scripts/fuse-tar-root
@@ -21,9 +21,12 @@
 
 ROOT_PARTITION=${ROOT_PARTITION:-1}
 ROOT_MOUNT=${TMP_DIR}/root
+DETECT_BLS_BOOT=${DETECT_BLS_BOOT:0}
+BOOT_MOUNT=${TMP_DIR}/boot
 
 echo 'Mounting root partition...'
 mount_part "${ROOT_PARTITION}" "${ROOT_MOUNT}"
+
 
 if [ -d curtin ] || [ -d "$CURTIN_HOOKS" ]; then
     echo 'Adding Curtin hooks...'
@@ -31,7 +34,20 @@ if [ -d curtin ] || [ -d "$CURTIN_HOOKS" ]; then
 fi
 
 echo "Creating MAAS image ${OUTPUT}..."
-tar -Sczpf "${OUTPUT}" --acls --selinux --xattrs -C "$ROOT_MOUNT" .
+TARFILE=${OUTPUT%*.gz}
+tar -Scpf "${TARFILE}" --acls --selinux --xattrs -C "$ROOT_MOUNT" .
+
+if [ "${DETECT_BLS_BOOT}" -eq 1 ]; then
+    echo "auto-detecting 'bls_boot' partition"
+    mount_disk "${TMP_DIR}"/disk
+    BOOT_PARTITION=$(parted -ms "${TMP_DIR}"/disk/nbd print | grep bls_boot | cut -d: -f1)
+    if [ -n "$BOOT_PARTITION" ]; then
+        mount_part "${BOOT_PARTITION}" "${BOOT_MOUNT}"
+        tar -Supf "${TARFILE}" --acls --selinux --xattrs -C "$TMP_DIR" boot/
+    fi
+fi
+
+gzip --best "${TARFILE}"
 
 if [ -n "$MANIFEST" ]; then
     echo "Creating manifest..."

--- a/ubuntu/Makefile
+++ b/ubuntu/Makefile
@@ -16,7 +16,7 @@ ISO=$(shell wget -O- -q ${URL}/${SERIES}/${SUMS} | grep live-server | cut -d'*' 
 
 all: custom-cloudimg.tar.gz
 
-$(eval $(call check_packages_deps,cloud-image-utils ovmf,cloud-image-utils ovmf))
+$(eval $(call check_packages_deps,cloud-image-utils ovmf parted,cloud-image-utils ovmf parted))
 
 lint:
 	packer validate .

--- a/ubuntu/README.md
+++ b/ubuntu/README.md
@@ -11,6 +11,7 @@ The Packer templates in this directory creates Ubuntu images for use with MAAS.
 * qemu-system
 * ovmf
 * cloud-image-utils
+* parted
 * [Packer](https://www.packer.io/intro/getting-started/install.html), v1.7.0 or newer
 
 ## Requirements (to deploy the image)
@@ -138,15 +139,19 @@ Installation is non-interactive.  Note that the installation will attempt an SSH
 ### Makefile Parameters
 
 #### PACKER_LOG
+
 Enable (1) or Disable (0) verbose packer logs. The default value is set to 0.
 
 #### SERIES
+
 Specify the Ubuntu Series to build. The default value is set to Jammy.
 
 #### URL
+
 The URL prefix for mirror that is hosting the ISO images for a given series. The default value is set to http://releases.ubuntu.com. ISO images are expected to be under URL/SERIES/.
 
 #### SUMS
+
 The file name for the checksums file. The default value is set to SHA256SUMS.
 
 ### Default Username

--- a/ubuntu/ubuntu-cloudimg.pkr.hcl
+++ b/ubuntu/ubuntu-cloudimg.pkr.hcl
@@ -117,6 +117,7 @@ build {
       "IMG_FMT=qcow2",
       "SOURCE=cloudimg",
       "ROOT_PARTITION=1",
+      "DETECT_BLS_BOOT=1",
       "OUTPUT=${var.filename}",
       "source ../scripts/fuse-nbd",
       "source ../scripts/fuse-tar-root"


### PR DESCRIPTION
newer Ubuntu releases have a Linux Boot Loader Specification compatible /boot partition. This should be included in the image.

fixes #175