### PR TITLE
Update .gitignore: exclude .env files and pyenv .python-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ ubuntu/packages/*.bin
 ubuntu/packages/*.tar.gz
 .vscode
 */http/*.ks
+.python-version
+.env
+.envrc


### PR DESCRIPTION
1. It is common to keep environment variables in either `.env` or `.envrc` files in the project root folder. To avoid accidental secrets leak, exclude `.env` files.
2. To support kickstart files validation and syntax highlighting `pykickstart` python package can be used together with "Kickstart Language Support" plugin for VScode. If python environment is managed with `pyenv`, make sure to exclude .python-version which is always local for user's environment.