### PR TITLE
Fix Debian preseed causing deployment failures

### DIFF
--- a/debian/curtin_userdata_custom_amd64
+++ b/debian/curtin_userdata_custom_amd64
@@ -16,8 +16,7 @@ late_commands:
   maas: [wget, '--no-proxy', '{{node_disable_pxe_url}}', '--post-data', '{{node_disable_pxe_data}}', '-O', '/dev/null']
   late_1: mount --bind $TARGET_MOUNT_POINT /mnt
   late_2: grep -A2 datasource /etc/cloud/cloud.cfg.d/91_kernel_cmdline_url.cfg | sed 's/curtin//' | tee /mnt/etc/cloud/cloud.cfg.d/debian.cfg
-  late_3: sed -i 's@ubuntu.com/ubuntu@debian.org/debian@g;s@archive@deb@g;s@ubuntu@debian@g;s@Ubuntu@Debian@g;' /mnt/etc/cloud/cloud.cfg
-  late 4: sed -i 's/security.debian.org\/debian/security.debian.org/g' /mnt/etc/cloud/cloud.cfg
+  late_3: sed -i 's@ubuntu.com/ubuntu@debian.org/debian@g;s@archive@deb@g;s@ubuntu@debian@g;s@Ubuntu@Debian@g;' /mnt/etc/cloud/cloud.cfg && sed -i 's/security.debian.org\/debian/security.debian.org/g' /mnt/etc/cloud/cloud.cfg
   late_5: debver=$(cat /mnt/etc/debian_version | awk -F. '{print $1}'); if [ ${debver} -eq 10 ]; then rel="buster"; elif [ ${debver} -eq 11 ]; then rel="bullseye"; elif [ ${debver} -eq 12 ]; then rel="bookworm"; fi; sed -i s/stable/${rel}/g /mnt/etc/apt/sources.list;
   late_6: sed -i '/^set -e/{n;N;d}' /mnt/etc/kernel/postinst.d/zz-update-grub
   late_7: rm -f /usr/local/bin/dpkg-query

--- a/debian/curtin_userdata_custom_arm64
+++ b/debian/curtin_userdata_custom_arm64
@@ -16,8 +16,7 @@ late_commands:
   maas: [wget, '--no-proxy', '{{node_disable_pxe_url}}', '--post-data', '{{node_disable_pxe_data}}', '-O', '/dev/null']
   late_1: mount --bind $TARGET_MOUNT_POINT /mnt
   late_2: grep -A2 datasource /etc/cloud/cloud.cfg.d/91_kernel_cmdline_url.cfg | sed 's/curtin//' | tee /mnt/etc/cloud/cloud.cfg.d/debian.cfg
-  late_3: sed -i 's@ubuntu.com/ubuntu@debian.org/debian@g;s@archive@deb@g;s@ubuntu@debian@g;s@Ubuntu@Debian@g;' /mnt/etc/cloud/cloud.cfg
-  late_4: sed -i 's/security.debian.org\/debian/security.debian.org/g' /mnt/etc/cloud/cloud.cfg
+  late_3: sed -i 's@ubuntu.com/ubuntu@debian.org/debian@g;s@archive@deb@g;s@ubuntu@debian@g;s@Ubuntu@Debian@g;' /mnt/etc/cloud/cloud.cfg && sed -i 's/security.debian.org\/debian/security.debian.org/g' /mnt/etc/cloud/cloud.cfg
   late_5: debver=$(cat /mnt/etc/debian_version | awk -F. '{print $1}'); if [ ${debver} -eq 10 ]; then rel="buster"; elif [ ${debver} -eq 11 ]; then rel="bullseye"; elif [ ${debver} -eq 12 ]; then rel="bookworm"; fi; sed -i s/stable/${rel}/g /mnt/etc/apt/sources.list;
   late_6: sed -i '/^set -e/{n;N;d}' /mnt/etc/kernel/postinst.d/zz-update-grub
   late_7: rm -f /usr/local/bin/dpkg-query


### PR DESCRIPTION
This resolves https://github.com/canonical/packer-maas/issues/206

I am not sure if this has always been a problem or just started occurring but with the current preseeds in the packer-maas repo deployments will fail with `late 4: sed -i 's/security.debian.org\/debian/security.debian.org/g' /mnt/etc/cloud/cloud.cfg` being unable to locate the `/mnt/etc/cloud/cloud.cfg` file (Which is rather strange seeing as the `sed` command just prior to this one is also targeting the same file and succeeds..)

I did a bit of testing and found that forcing the `sed` commands targetting the same file to run seqentually via `&&` resolved this for me. My hunch is that MAAS is trying to run the second `sed` command before the first has completed - That being said I did try to put a `sleep 10` between the two `sed`s and it did not resolve the problem so i could be incorrect there. 