### PR TITLE
add ARCH makefile command to ubuntu

### DIFF
--- a/ubuntu/Makefile
+++ b/ubuntu/Makefile
@@ -7,6 +7,7 @@ PACKER_LOG ?= 0
 export PACKER_LOG
 
 SERIES ?= jammy
+ARCH ?= amd64
 URL ?= http://releases.ubuntu.com
 SUMS ?= SHA256SUMS
 
@@ -35,18 +36,23 @@ OVMF_VARS.fd: /usr/share/OVMF/OVMF_VARS.fd
 	cp -v $< $@
 
 custom-cloudimg.tar.gz: check-deps clean
-	${PACKER} init . && ${PACKER} build -only='cloudimg.*' -var ubuntu_series=${SERIES} .
+	${PACKER} init . && ${PACKER} build \
+		-only='cloudimg.*' \
+		-var ubuntu_series=${SERIES} \
+		-var architecture=${ARCH} .
 
 custom-ubuntu.tar.gz: check-deps clean seeds-flat.iso OVMF_VARS.fd \
 			packages/custom-packages.tar.gz
 	${PACKER} init . && ${PACKER} build -only=qemu.flat \
 	                -var ubuntu_series=${SERIES} \
-	                -var ubuntu_iso=${ISO} .
+	                -var ubuntu_iso=${ISO} \
+					-var architecture=${ARCH} .
 
 custom-ubuntu-lvm.dd.gz: check-deps clean seeds-lvm.iso OVMF_VARS.fd
 	${PACKER} init . && ${PACKER} build -only=qemu.lvm \
 	                -var ubuntu_series=${SERIES} \
-	                -var ubuntu_lvm_iso=${ISO} .
+	                -var ubuntu_lvm_iso=${ISO} \
+					-var architecture=${ARCH} .
 clean:
 	${RM} -rf output-* custom-*.gz \
 		seeds-flat.iso seeds-lvm.iso seeds-cloudimg.iso \

--- a/ubuntu/Makefile
+++ b/ubuntu/Makefile
@@ -46,13 +46,13 @@ custom-ubuntu.tar.gz: check-deps clean seeds-flat.iso OVMF_VARS.fd \
 	${PACKER} init . && ${PACKER} build -only=qemu.flat \
 	                -var ubuntu_series=${SERIES} \
 	                -var ubuntu_iso=${ISO} \
-					-var architecture=${ARCH} .
+			-var architecture=${ARCH} .
 
 custom-ubuntu-lvm.dd.gz: check-deps clean seeds-lvm.iso OVMF_VARS.fd
 	${PACKER} init . && ${PACKER} build -only=qemu.lvm \
 	                -var ubuntu_series=${SERIES} \
 	                -var ubuntu_lvm_iso=${ISO} \
-					-var architecture=${ARCH} .
+			-var architecture=${ARCH} .
 clean:
 	${RM} -rf output-* custom-*.gz \
 		seeds-flat.iso seeds-lvm.iso seeds-cloudimg.iso \

--- a/ubuntu/README.md
+++ b/ubuntu/README.md
@@ -146,6 +146,10 @@ Enable (1) or Disable (0) verbose packer logs. The default value is set to 0.
 
 Specify the Ubuntu Series to build. The default value is set to Jammy.
 
+#### ARCH
+
+Target image architecture. Supported values are amd64 (default) and arm64.
+
 #### URL
 
 The URL prefix for mirror that is hosting the ISO images for a given series. The default value is set to http://releases.ubuntu.com. ISO images are expected to be under URL/SERIES/.


### PR DESCRIPTION
Ubuntu images have the architecture option, we should expose this as a makefile parameter as we do with debian.