### PR TITLE
Add TIMEOUT option when building images

### DIFF
--- a/alma8/Makefile
+++ b/alma8/Makefile
@@ -4,6 +4,7 @@ include ../scripts/check.mk
 
 PACKER ?= packer
 PACKER_LOG ?= 0
+TIMEOUT ?= 1h
 
 export PACKER_LOG
 
@@ -14,7 +15,7 @@ all: alma8.tar.gz
 $(eval $(call check_packages_deps))
 
 alma8.tar.gz: check-deps clean
-	${PACKER} init alma8.pkr.hcl && ${PACKER} build alma8.pkr.hcl
+	${PACKER} init alma8.pkr.hcl && ${PACKER} build -var timeout=${TIMEOUT} alma8.pkr.hcl
 
 clean:
 	${RM} -rf output-alma8 alma8.tar.gz

--- a/alma8/README.md
+++ b/alma8/README.md
@@ -57,6 +57,12 @@ The installation runs in a non-interactive mode.
 
 Note: alma8.pkr.hcl runs Packer in headless mode, with the serial port output from qemu redirected to stdio to give feedback on image creation process. If you wish to see more, change the value of `headless` to `false` in alma8.pkr.hcl, remove `[ "-serial", "stdio" ]` from `qemuargs` section and select `View`, then `serial0` in the qemu window that appears during build. This lets you watch progress of the image build script. Press `ctrl-b 2` to switch to shell to explore more, and `ctrl-b 1` to go back to log view.
 
+### Makefile Parameters
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ## Uploading an image to MAAS
 
 ```shell

--- a/alma8/alma8.pkr.hcl
+++ b/alma8/alma8.pkr.hcl
@@ -55,6 +55,12 @@ variable ks_mirror {
   default = "${env("KS_MIRROR")}"
 }
 
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
 locals {
   ks_proxy           = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
   ks_os_repos        = var.ks_mirror != "" ? "--url=${var.ks_mirror}/BaseOS/x86_64/os" : var.ks_os_repos
@@ -72,7 +78,7 @@ source "qemu" "alma8" {
   iso_url          = var.alma_iso_url
   memory           = 2048
   qemuargs         = [["-serial", "stdio"]]
-  shutdown_timeout = "1h"
+  shutdown_timeout = var.timeout
   http_content = {
     "/alma8.ks" = templatefile("${path.root}/http/alma8.ks.pkrtpl.hcl",
       {

--- a/alma9/Makefile
+++ b/alma9/Makefile
@@ -4,6 +4,7 @@ include ../scripts/check.mk
 
 PACKER ?= packer
 PACKER_LOG ?= 0
+TIMEOUT ?= 1h
 
 export PACKER_LOG
 
@@ -14,7 +15,7 @@ all: alma9.tar.gz
 $(eval $(call check_packages_deps))
 
 alma9.tar.gz: check-deps clean
-	${PACKER} init alma9.pkr.hcl && ${PACKER} build alma9.pkr.hcl
+	${PACKER} init alma9.pkr.hcl && ${PACKER} build -var timeout=${TIMEOUT} alma9.pkr.hcl
 
 clean:
 	${RM} -rf output-alma9 alma9.tar.gz

--- a/alma9/README.md
+++ b/alma9/README.md
@@ -57,6 +57,12 @@ The installation runs in a non-interactive mode.
 
 Note: alma9.pkr.hcl runs Packer in headless mode, with the serial port output from qemu redirected to stdio to give feedback on image creation process. If you wish to see more, change the value of `headless` to `false` in alma9.pkr.hcl, remove `[ "-serial", "stdio" ]` from `qemuargs` section and select `View`, then `serial0` in the qemu window that appears during build. This lets you watch progress of the image build script. Press `ctrl-b 2` to switch to shell to explore more, and `ctrl-b 1` to go back to log view.
 
+### Makefile Parameters
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ## Uploading an image to MAAS
 
 ```shell

--- a/alma9/alma9.pkr.hcl
+++ b/alma9/alma9.pkr.hcl
@@ -61,6 +61,12 @@ variable ks_mirror {
   default = "${env("KS_MIRROR")}"
 }
 
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
 locals {
   ks_proxy           = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
   ks_os_repos        = var.ks_mirror != "" ? "--url=${var.ks_mirror}/BaseOS/x86_64/os" : var.ks_os_repos
@@ -78,7 +84,7 @@ source "qemu" "alma9" {
   iso_url          = "${var.alma_iso_url}"
   memory           = 2048
   qemuargs         = [["-serial", "stdio"], ["-cpu", "host"]]
-  shutdown_timeout = "1h"
+  shutdown_timeout = var.timeout
   http_content = {
     "/alma9.ks" = templatefile("${path.root}/http/alma9.ks.pkrtpl.hcl",
       {

--- a/centos6/Makefile
+++ b/centos6/Makefile
@@ -4,6 +4,7 @@ include ../scripts/check.mk
 
 PACKER ?= packer
 PACKER_LOG ?= 0
+TIMEOUT ?= 1h
 
 export PACKER_LOG
 
@@ -14,7 +15,7 @@ all: centos6.tar.gz
 $(eval $(call check_packages_deps))
 
 centos6.tar.gz: check-deps clean
-	${PACKER} init centos6.pkr.hcl && ${PACKER} build centos6.pkr.hcl
+	${PACKER} init centos6.pkr.hcl && ${PACKER} build -var timeout=${TIMEOUT} centos6.pkr.hcl
 
 clean:
 	${RM} -rf output-centos6 centos6.tar.gz

--- a/centos6/README.md
+++ b/centos6/README.md
@@ -57,6 +57,12 @@ centos6.pkr.hcl.
 
 Installation is non-interactive.
 
+### Makefile Parameters
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ## Uploading an image to MAAS
 
 ```shell

--- a/centos6/centos6.pkr.hcl
+++ b/centos6/centos6.pkr.hcl
@@ -64,6 +64,12 @@ variable ks_mirror {
   default = "${env("KS_MIRROR")}"
 }
 
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
 locals {
   ks_proxy         = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
   ks_os_repos      = var.ks_mirror != "" ? "--url=${var.ks_mirror}/os/x86_64" : var.ks_os_repos
@@ -81,7 +87,7 @@ source "qemu" "centos6" {
   iso_url          = var.centos6_iso_url
   memory           = 2048
   qemuargs         = [["-serial", "stdio"]]
-  shutdown_timeout = "1h"
+  shutdown_timeout = var.timeout
   http_content = {
     "/centos6.ks" = templatefile("${path.root}/http/centos6.ks.pkrtpl.hcl",
       {

--- a/centos7/Makefile
+++ b/centos7/Makefile
@@ -4,6 +4,7 @@ include ../scripts/check.mk
 
 PACKER ?= packer
 PACKER_LOG ?= 0
+TIMEOUT ?= 1h
 
 export PACKER_LOG
 
@@ -14,7 +15,7 @@ all: centos7.tar.gz
 $(eval $(call check_packages_deps))
 
 centos7.tar.gz: clean check-deps
-	${PACKER} init centos7.pkr.hcl && ${PACKER} build centos7.pkr.hcl
+	${PACKER} init centos7.pkr.hcl && ${PACKER} build -var timeout=${TIMEOUT} centos7.pkr.hcl
 
 clean:
 	${RM} -rf output-centos7 centos7.tar.gz

--- a/centos7/README.md
+++ b/centos7/README.md
@@ -67,6 +67,12 @@ centos7.pkr.hcl.
 
 Installation is non-interactive.
 
+### Makefile Parameters
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ## Uploading an image to MAAS
 
 ```shell

--- a/centos7/centos7.pkr.hcl
+++ b/centos7/centos7.pkr.hcl
@@ -55,6 +55,12 @@ variable ks_mirror {
   default = "${env("KS_MIRROR")}"
 }
 
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
 locals {
   ks_proxy         = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
   ks_os_repos      = var.ks_mirror != "" ? "--url=${var.ks_mirror}/os/x86_64" : var.ks_os_repos
@@ -72,7 +78,7 @@ source "qemu" "centos7" {
   iso_url          = var.centos7_iso_url
   memory           = 2048
   qemuargs         = [["-serial", "stdio"]]
-  shutdown_timeout = "1h"
+  shutdown_timeout = var.timeout
   http_content = {
     "/centos7.ks" = templatefile("${path.root}/http/centos7.ks.pkrtpl.hcl",
       {

--- a/centos8-stream/Makefile
+++ b/centos8-stream/Makefile
@@ -4,6 +4,7 @@ include ../scripts/check.mk
 
 PACKER ?= packer
 PACKER_LOG ?= 0
+TIMEOUT ?= 1h
 
 export PACKER_LOG
 
@@ -14,7 +15,7 @@ all: centos8-stream.tar.gz
 $(eval $(call check_packages_deps))
 
 centos8-stream.tar.gz: check-deps clean
-	${PACKER} init centos8-stream.pkr.hcl && ${PACKER} build centos8-stream.pkr.hcl
+	${PACKER} init centos8-stream.pkr.hcl && ${PACKER} build -var timeout=${TIMEOUT} centos8-stream.pkr.hcl
 
 clean:
 	${RM} -rf output-centos8-stream centos8-stream.tar.gz

--- a/centos8-stream/README.md
+++ b/centos8-stream/README.md
@@ -62,6 +62,12 @@ centos8-stream.pkr.hcl.
 
 Installation is non-interactive.
 
+### Makefile Parameters
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ## Uploading an image to MAAS
 
 ```shell

--- a/centos8-stream/centos8-stream.pkr.hcl
+++ b/centos8-stream/centos8-stream.pkr.hcl
@@ -52,6 +52,12 @@ variable ks_mirror {
   default = "${env("KS_MIRROR")}"
 }
 
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
 locals {
   ks_proxy           = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
   ks_os_repos        = var.ks_mirror != "" ? "--url=${var.ks_mirror}/os/x86_64" : var.ks_os_repos
@@ -69,7 +75,7 @@ source "qemu" "centos8-stream" {
   iso_url          = var.centos8_stream_iso_url
   memory           = 2048
   qemuargs         = [["-serial", "stdio"]]
-  shutdown_timeout = "1h"
+  shutdown_timeout = var.timeout
   http_content = {
     "/centos8-stream.ks" = templatefile("${path.root}/http/centos8-stream.ks.pkrtpl.hcl",
       {

--- a/centos8/Makefile
+++ b/centos8/Makefile
@@ -5,6 +5,7 @@ include ../scripts/check.mk
 PACKER ?= packer
 PACKER_LOG ?= 0
 KS_MIRROR ?= http://mirrorlist.centos.org
+TIMEOUT ?= 1h
 export PACKER_LOG
 
 .PHONY: all clean
@@ -14,7 +15,7 @@ all: centos8.tar.gz
 $(eval $(call check_packages_deps))
 
 centos8.tar.gz: check-deps clean 
-	${PACKER} init centos8.pkr.hcl && ${PACKER} build centos8.pkr.hcl
+	${PACKER} init centos8.pkr.hcl && ${PACKER} build -var timeout=${TIMEOUT} centos8.pkr.hcl
 
 clean:
 	${RM} -rf output-centos8 centos8.tar.gz 

--- a/centos8/README.md
+++ b/centos8/README.md
@@ -62,6 +62,12 @@ centos8.pkr.hcl.
 
 Installation is non-interactive.
 
+### Makefile Parameters
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ## Uploading an image to MAAS
 
 ```shell

--- a/centos8/centos8.pkr.hcl
+++ b/centos8/centos8.pkr.hcl
@@ -52,6 +52,12 @@ variable ks_mirror {
   default = "${env("KS_MIRROR")}"
 }
 
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
 locals {
   ks_proxy        = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
   ks_os_repos     = var.ks_mirror != "" ? "--url=${var.ks_mirror}/os/x86_64" : var.ks_os_repos
@@ -68,7 +74,7 @@ source "qemu" "centos8" {
   iso_url          = var.centos8_iso_url
   memory           = 2048
   qemuargs         = [["-serial", "stdio"]]
-  shutdown_timeout = "1h"
+  shutdown_timeout = var.timeout
   http_content = {
     "/centos8.ks" = templatefile("${path.root}/http/centos7.ks.pkrtpl.hcl",
       {

--- a/centos9-stream/Makefile
+++ b/centos9-stream/Makefile
@@ -4,6 +4,7 @@ include ../scripts/check.mk
 
 PACKER ?= packer
 PACKER_LOG ?= 0
+TIMEOUT ?= 1h
 
 export PACKER_LOG
 
@@ -14,7 +15,7 @@ all: centos9-stream.tar.gz
 $(eval $(call check_packages_deps))
 
 centos9-stream.tar.gz: check-deps clean
-	${PACKER} init centos9-stream.pkr.hcl && ${PACKER} build centos9-stream.pkr.hcl
+	${PACKER} init centos9-stream.pkr.hcl && ${PACKER} build -var timeout=${TIMEOUT} centos9-stream.pkr.hcl
 
 clean:
 	${RM} -rf output-centos9-stream centos9-stream.tar.gz

--- a/centos9-stream/README.md
+++ b/centos9-stream/README.md
@@ -61,6 +61,12 @@ centos9-stream.pkr.hcl.
 
 Installation is non-interactive.
 
+### Makefile Parameters
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ## Uploading an image to MAAS
 
 ```shell

--- a/centos9-stream/centos9-stream.pkr.hcl
+++ b/centos9-stream/centos9-stream.pkr.hcl
@@ -58,6 +58,12 @@ variable ks_mirror {
   default = "${env("KS_MIRROR")}"
 }
 
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
 locals {
   ks_proxy           = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
   ks_os_repos        = var.ks_mirror != "" ? "--url=${var.ks_mirror}/BaseOS/x86_64" : var.ks_os_repos
@@ -76,7 +82,7 @@ source "qemu" "centos9-stream" {
   iso_url          = var.centos9_stream_iso_url
   memory           = 2048
   qemuargs         = [["-serial", "stdio"], ["-cpu", "host"]]
-  shutdown_timeout = "1h"
+  shutdown_timeout = var.timeout
   http_content = {
     "/centos9-stream.ks" = templatefile("${path.root}/http/centos9-stream.ks.pkrtpl.hcl",
       {

--- a/debian/Makefile
+++ b/debian/Makefile
@@ -9,6 +9,7 @@ export PACKER_LOG
 SERIES ?= bullseye
 BOOT ?= uefi
 ARCH ?= amd64
+TIMEOUT ?= 1h
 
 ifeq ($(strip $(SERIES)),buster)
 	VERSION = 10
@@ -46,7 +47,8 @@ debian: check-deps clean
 		-var debian_series=${SERIES} \
 		-var debian_version=${VERSION} \
 		-var architecture=${ARCH} \
-		-var boot_mode=${BOOT} .
+		-var boot_mode=${BOOT} \
+		-var timeout=${TIMEOUT} .
 
 clean:
 	${RM} -rf output-* debian-custom-*.gz \

--- a/debian/README.md
+++ b/debian/README.md
@@ -129,6 +129,10 @@ for amd64 architecture.
 
 Target image architecture. Supported values are amd64 (default) and arm64.
 
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ### Default Username
 
 The default username is ```debian```

--- a/debian/debian-cloudimg.pkr.hcl
+++ b/debian/debian-cloudimg.pkr.hcl
@@ -54,9 +54,9 @@ source "qemu" "cloudimg" {
   shutdown_command       = "sudo -S shutdown -P now"
   ssh_handshake_attempts = 50
   ssh_password           = var.ssh_password
-  ssh_timeout            = "15m"
+  ssh_timeout            = var.timeout
   ssh_username           = var.ssh_username
-  ssh_wait_timeout       = "15m"
+  ssh_wait_timeout       = var.timeout
   use_backing_file       = true
 }
 

--- a/debian/variables.pkr.hcl
+++ b/debian/variables.pkr.hcl
@@ -48,3 +48,9 @@ variable "ssh_debian_password" {
   type    = string
   default = "debian"
 }
+
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}

--- a/ol8/Makefile
+++ b/ol8/Makefile
@@ -4,6 +4,7 @@ include ../scripts/check.mk
 
 PACKER ?= packer
 PACKER_LOG ?= 0
+TIMEOUT ?= 1h
 
 export PACKER_LOG
 
@@ -14,7 +15,7 @@ all: ol8.tar.gz
 $(eval $(call check_packages_deps))
 
 ol8.tar.gz: check-deps clean
-	${PACKER} init ol8.pkr.hcl && ${PACKER} build ol8.pkr.hcl
+	${PACKER} init ol8.pkr.hcl && ${PACKER} build -var timeout=${TIMEOUT} ol8.pkr.hcl
 
 clean:
 	${RM} -rf output-ol8 ol8.tar.gz

--- a/ol8/README.md
+++ b/ol8/README.md
@@ -57,6 +57,12 @@ ol8.pkr.hcl.
 
 Installation is non-interactive.
 
+### Makefile Parameters
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ## Uploading an image to MAAS
 
 ```shell

--- a/ol8/ol8.pkr.hcl
+++ b/ol8/ol8.pkr.hcl
@@ -46,6 +46,12 @@ variable ks_mirror {
   default = "${env("KS_MIRROR")}"
 }
 
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
 locals {
   ks_proxy           = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
   ks_os_repos        = var.ks_mirror != "" ? "--url=${var.ks_mirror}/baseos/latest/x86_64" : var.ks_os_repos
@@ -62,7 +68,7 @@ source "qemu" "ol8" {
   iso_url          = var.ol8_iso_url
   memory           = 2048
   qemuargs         = [["-serial", "stdio"], ["-cpu", "host"]]
-  shutdown_timeout = "1h"
+  shutdown_timeout = var.timeout
   http_content = {
     "/ol8.ks" = templatefile("${path.root}/http/ol8.ks.pkrtpl.hcl",
       {

--- a/ol9/Makefile
+++ b/ol9/Makefile
@@ -4,6 +4,7 @@ include ../scripts/check.mk
 
 PACKER ?= packer
 PACKER_LOG ?= 0
+TIMEOUT ?= 1h
 
 export PACKER_LOG
 
@@ -14,7 +15,7 @@ all: ol9.tar.gz
 $(eval $(call check_packages_deps))
 
 ol9.tar.gz: check-deps clean
-	${PACKER} init ol9.pkr.hcl && ${PACKER} build ol9.pkr.hcl
+	${PACKER} init ol9.pkr.hcl && ${PACKER} build -var timeout=${TIMEOUT} ol9.pkr.hcl
 
 clean:
 	${RM} -rf output-ol9 ol9.tar.gz

--- a/ol9/README.md
+++ b/ol9/README.md
@@ -57,6 +57,12 @@ ol9.pkr.hcl.
 
 Installation is non-interactive.
 
+### Makefile Parameters
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ## Uploading an image to MAAS
 
 ```shell

--- a/ol9/ol9.pkr.hcl
+++ b/ol9/ol9.pkr.hcl
@@ -46,6 +46,12 @@ variable ks_mirror {
   default = "${env("KS_MIRROR")}"
 }
 
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
 locals {
   ks_proxy           = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
   ks_os_repos        = var.ks_mirror != "" ? "--url=${var.ks_mirror}/baseos/latest/x86_64" : var.ks_os_repos
@@ -62,7 +68,7 @@ source "qemu" "ol9" {
   iso_url          = var.ol9_iso_url
   memory           = 2048
   qemuargs         = [["-serial", "stdio"], ["-cpu", "host"]]
-  shutdown_timeout = "1h"
+  shutdown_timeout = var.timeout
   http_content = {
     "/ol9.ks" = templatefile("${path.root}/http/ol9.ks.pkrtpl.hcl",
       {

--- a/rhel7/Makefile
+++ b/rhel7/Makefile
@@ -5,6 +5,7 @@ include ../scripts/check.mk
 PACKER ?= packer
 PACKER_LOG ?= 0
 ISO ?= ${RHEL7_ISO_PATH}
+TIMEOUT ?= 1h
 
 export PACKER_LOG
 
@@ -15,7 +16,7 @@ all: rhel7.tar.gz
 $(eval $(call check_packages_deps))
 
 rhel7.tar.gz: check-deps clean
-	${PACKER} init rhel7.pkr.hcl && ${PACKER} build -var "rhel7_iso_path=${ISO}" rhel7.pkr.hcl
+	${PACKER} init rhel7.pkr.hcl && ${PACKER} build -var "rhel7_iso_path=${ISO}" -var timeout=${TIMEOUT} rhel7.pkr.hcl
 
 clean:
 	${RM} -rf output-rhel7 rhel7.tar.gz 

--- a/rhel7/README.md
+++ b/rhel7/README.md
@@ -54,6 +54,12 @@ rhel7.pkr.hcl.
 
 Installation is non-interactive.
 
+### Makefile Parameters
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ## Uploading an image to MAAS
 
 ```shell

--- a/rhel7/rhel7.pkr.hcl
+++ b/rhel7/rhel7.pkr.hcl
@@ -36,6 +36,12 @@ variable ks_proxy {
   default = "${env("KS_PROXY")}"
 }
 
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
 locals {
   ks_proxy = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
 }
@@ -50,7 +56,7 @@ source "qemu" "rhel7" {
   iso_url          = var.rhel7_iso_path
   memory           = 2048
   qemuargs         = [["-serial", "stdio"]]
-  shutdown_timeout = "1h"
+  shutdown_timeout = var.timeout
   http_content = {
     "/rhel7.ks" = templatefile("${path.root}/http/rhel7.ks.pkrtpl.hcl",
       {

--- a/rhel8/Makefile
+++ b/rhel8/Makefile
@@ -5,6 +5,7 @@ include ../scripts/check.mk
 PACKER ?= packer
 PACKER_LOG ?= 0
 ISO ?= ${RHEL8_ISO_PATH}
+TIMEOUT ?= 1h
 
 export PACKER_LOG
 
@@ -15,7 +16,7 @@ all: rhel8.tar.gz
 $(eval $(call check_packages_deps))
 
 rhel8.tar.gz: check-deps clean
-	${PACKER} init rhel8.pkr.hcl && ${PACKER} build -var "rhel8_iso_path=${ISO}" rhel8.pkr.hcl
+	${PACKER} init rhel8.pkr.hcl && ${PACKER} build -var "rhel8_iso_path=${ISO}" -var timeout=${TIMEOUT} rhel8.pkr.hcl
 
 clean:
 	${RM} -rf output-rhel8 rhel8.tar.gz

--- a/rhel8/README.md
+++ b/rhel8/README.md
@@ -54,6 +54,12 @@ rhel8.pkr.hcl.
 
 Installation is non-interactive.
 
+### Makefile Parameters
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ## Uploading an image to MAAS
 
 ```shell

--- a/rhel8/rhel8.pkr.hcl
+++ b/rhel8/rhel8.pkr.hcl
@@ -30,6 +30,12 @@ variable ks_proxy {
   default = "${env("KS_PROXY")}"
 }
 
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
 locals {
   ks_proxy = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
 }
@@ -44,7 +50,7 @@ source "qemu" "rhel8" {
   iso_url          = var.rhel8_iso_path
   memory           = 2048
   qemuargs         = [["-serial", "stdio"], ["-cpu", "host"]]
-  shutdown_timeout = "1h"
+  shutdown_timeout = var.timeout
   http_content = {
     "/rhel8.ks" = templatefile("${path.root}/http/rhel8.ks.pkrtpl.hcl",
       {

--- a/rhel9/Makefile
+++ b/rhel9/Makefile
@@ -5,6 +5,7 @@ include ../scripts/check.mk
 PACKER ?= packer
 PACKER_LOG ?= 0
 ISO ?= rhel-baseos-9.1-x86_64-dvd.iso
+TIMEOUT ?= 1h
 
 export PACKER_LOG
 
@@ -15,7 +16,7 @@ all: rhel9.tar.gz
 $(eval $(call check_packages_deps))
 
 rhel9.tar.gz: check-deps clean
-	${PACKER} init rhel9.pkr.hcl && ${PACKER} build -var "rhel9_iso_path=${ISO}" rhel9.pkr.hcl
+	${PACKER} init rhel9.pkr.hcl && ${PACKER} build -var "rhel9_iso_path=${ISO}" -var timeout=${TIMEOUT} rhel9.pkr.hcl
 
 clean:
 	${RM} -rf output-rhel9 rhel9.tar.gz

--- a/rhel9/README.md
+++ b/rhel9/README.md
@@ -54,6 +54,12 @@ rhel9.pkr.hcl.
 
 Installation is non-interactive.
 
+### Makefile Parameters
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ## Uploading an image to MAAS
 
 ```shell

--- a/rhel9/rhel9.pkr.hcl
+++ b/rhel9/rhel9.pkr.hcl
@@ -30,6 +30,12 @@ variable ks_proxy {
   default = "${env("KS_PROXY")}"
 }
 
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
 locals {
   ks_proxy = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
 }
@@ -44,7 +50,7 @@ source "qemu" "rhel9" {
   iso_url          = var.rhel9_iso_path
   memory           = 2048
   qemuargs         = [["-serial", "stdio"], ["-cpu", "host"]]
-  shutdown_timeout = "1h"
+  shutdown_timeout = var.timeout
   http_content = {
     "/rhel9.ks" = templatefile("${path.root}/http/rhel9.ks.pkrtpl.hcl",
       {

--- a/rocky8/Makefile
+++ b/rocky8/Makefile
@@ -4,6 +4,7 @@ include ../scripts/check.mk
 
 PACKER ?= packer
 PACKER_LOG ?= 0
+TIMEOUT ?= 1h
 
 export PACKER_LOG
 
@@ -14,7 +15,7 @@ all: rocky8.tar.gz
 $(eval $(call check_packages_deps))
 
 rocky8.tar.gz: check-deps clean
-	${PACKER} init rocky8.pkr.hcl && ${PACKER} build rocky8.pkr.hcl
+	${PACKER} init rocky8.pkr.hcl && ${PACKER} build -var timeout=${TIMEOUT} rocky8.pkr.hcl
 
 clean:
 	${RM} -rf output-rocky8 rocky8.tar.gz

--- a/rocky8/README.md
+++ b/rocky8/README.md
@@ -57,6 +57,12 @@ The installation runs in a non-interactive mode.
 
 Note: rocky8.pkr.hcl runs Packer in headless mode, with the serial port output from qemu redirected to stdio to give feedback on image creation process. If you wish to see more, change the value of `headless` to `false` in rocky8.pkr.hcl, remove `[ "-serial", "stdio" ]` from `qemuargs` section and select `View`, then `serial0` in the qemu window that appears during build. This lets you watch progress of the image build script. Press `ctrl-b 2` to switch to shell to explore more, and `ctrl-b 1` to go back to log view.
 
+### Makefile Parameters
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ## Uploading an image to MAAS
 
 ```shell

--- a/rocky8/rocky8.pkr.hcl
+++ b/rocky8/rocky8.pkr.hcl
@@ -55,6 +55,12 @@ variable ks_mirror {
   default = "${env("KS_MIRROR")}"
 }
 
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
 locals {
   ks_proxy           = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
   ks_os_repos        = var.ks_mirror != "" ? "--url=${var.ks_mirror}/BaseOS/x86_64/os" : var.ks_os_repos
@@ -72,7 +78,7 @@ source "qemu" "rocky8" {
   iso_url          = var.rocky_iso_url
   memory           = 2048
   qemuargs         = [["-serial", "stdio"]]
-  shutdown_timeout = "1h"
+  shutdown_timeout = var.timeout
   http_content = {
     "/rocky8.ks" = templatefile("${path.root}/http/rocky8.ks.pkrtpl.hcl",
       {

--- a/rocky9/Makefile
+++ b/rocky9/Makefile
@@ -4,6 +4,7 @@ include ../scripts/check.mk
 
 PACKER ?= packer
 PACKER_LOG ?= 0
+TIMEOUT ?= 1h
 
 export PACKER_LOG
 
@@ -14,7 +15,7 @@ all: rocky9.tar.gz
 $(eval $(call check_packages_deps))
 
 rocky9.tar.gz: check-deps clean
-	${PACKER} init rocky9.pkr.hcl && ${PACKER} build rocky9.pkr.hcl
+	${PACKER} init rocky9.pkr.hcl && ${PACKER} build -var timeout=${TIMEOUT} rocky9.pkr.hcl
 
 clean:
 	${RM} -rf output-rocky9 rocky9.tar.gz

--- a/rocky9/README.md
+++ b/rocky9/README.md
@@ -48,6 +48,12 @@ The installation runs in a non-interactive mode.
 
 Note: rocky9.pkr.hcl runs Packer in headless mode, with the serial port output from qemu redirected to stdio to give feedback on image creation process. If you wish to see more, change the value of `headless` to `false` in rocky9.pkr.hcl, remove `[ "-serial", "stdio" ]` from `qemuargs` section and select `View`, then `serial0` in the qemu window that appears during build. This lets you watch progress of the image build script. Press `ctrl-b 2` to switch to shell to explore more, and `ctrl-b 1` to go back to log view.
 
+### Makefile Parameters
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ## Uploading an image to MAAS
 
 ```shell

--- a/rocky9/rocky9.pkr.hcl
+++ b/rocky9/rocky9.pkr.hcl
@@ -64,6 +64,12 @@ variable ks_mirror {
   default = "${env("KS_MIRROR")}"
 }
 
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
 locals {
   ks_proxy           = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
   ks_os_repos        = var.ks_mirror != "" ? "--url=${var.ks_mirror}/BaseOS/x86_64/os" : var.ks_os_repos
@@ -82,7 +88,7 @@ source "qemu" "rocky9" {
   iso_url          = "${var.rocky_iso_url}"
   memory           = 2048
   qemuargs         = [["-serial", "stdio"], ["-cpu", "host"]]
-  shutdown_timeout = "1h"
+  shutdown_timeout = var.timeout
   http_content = {
     "/rocky.ks" = templatefile("${path.root}/http/rocky.ks.pkrtpl.hcl",
       {

--- a/sles12/Makefile
+++ b/sles12/Makefile
@@ -6,6 +6,7 @@ PACKER ?= packer
 PACKER_LOG ?= 0
 export PACKER_LOG
 ISO ?= SLES12-SP5-JeOS.x86_64-12.5-OpenStack-Cloud-GM.qcow2
+TIMEOUT ?= 1h
 
 .PHONY: all clean
 
@@ -14,7 +15,7 @@ all: sles12.tar.gz
 $(eval $(call check_packages_deps))
 
 sles12.tar.gz: check-deps clean
-	${PACKER} init sles.pkr.hcl && ${PACKER} build -var "sles12_iso_path=${ISO}" -on-error=ask sles.pkr.hcl
+	${PACKER} init sles.pkr.hcl && ${PACKER} build -var "sles12_iso_path=${ISO}" -var timeout=${TIMEOUT} -on-error=ask sles.pkr.hcl
 
 clean:
 	${RM} -rf output-sles12 sles12.tar.gz

--- a/sles12/README.md
+++ b/sles12/README.md
@@ -40,6 +40,12 @@ Note: `sles.pkr.hcl` is configured to run Packer in headless mode. Only Packer o
 
 Installation is non-interactive.
 
+### Makefile Parameters
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ## Uploading an image to MAAS
 
 ```shell

--- a/sles12/sles.pkr.hcl
+++ b/sles12/sles.pkr.hcl
@@ -55,6 +55,12 @@ variable "sles12_iso_path" {
   default = "${env("SLES12_ISO_PATH")}"
 }
 
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
 locals {
   qemu_arch    = "x86_64"
   uefi_imp     = "OVMF"
@@ -98,9 +104,9 @@ source "qemu" "sles12" {
   shutdown_command       = "sudo -S shutdown -P now"
   ssh_handshake_attempts = 500
   ssh_password           = var.ssh_password
-  ssh_timeout            = "45m"
+  ssh_timeout            = var.timeout
   ssh_username           = var.ssh_username
-  ssh_wait_timeout       = "45m"
+  ssh_wait_timeout       = var.timeout
   use_backing_file       = true
 }
 

--- a/sles15/Makefile
+++ b/sles15/Makefile
@@ -6,6 +6,7 @@ PACKER ?= packer
 PACKER_LOG ?= 0
 export PACKER_LOG
 ISO ?= SLE-15-SP4-Full-x86_64-GM-Media1.iso
+TIMEOUT ?= 1h
 
 .PHONY: all clean
 
@@ -14,7 +15,7 @@ all: sles15.tar.gz
 $(eval $(call check_packages_deps))
 
 sles15.tar.gz: check-deps clean
-	${PACKER} init sles.pkr.hcl && ${PACKER} build -var "sles15_iso_path=${ISO}" -on-error=ask sles.pkr.hcl
+	${PACKER} init sles.pkr.hcl && ${PACKER} build -var "sles15_iso_path=${ISO}" -var timeout=${TIMEOUT} -on-error=ask sles.pkr.hcl
 
 clean:
 	${RM} -rf output-sles15 sles15.tar.gz

--- a/sles15/README.md
+++ b/sles15/README.md
@@ -48,6 +48,12 @@ VNC port given in the Packer output or change the value of `headless` to false i
 
 Installation is non-interactive.
 
+### Makefile Parameters
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ## Uploading an image to MAAS
 
 ```shell

--- a/sles15/sles.pkr.hcl
+++ b/sles15/sles.pkr.hcl
@@ -19,6 +19,12 @@ variable "sles15_iso_path" {
   default = "${env("SLES15_ISO_PATH")}"
 }
 
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
 source "qemu" "sles15" {
   boot_command     = ["<esc><enter><wait>", "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>", " lang=en_US autoyast=http://{{ .HTTPIP }}:{{ .HTTPPort }}/sles15.xml<wait>", " textmode=1<wait>", "<enter><wait>"]
   boot_wait        = "3s"
@@ -30,7 +36,7 @@ source "qemu" "sles15" {
   iso_url          = var.sles15_iso_path
   memory           = 4096
   qemuargs         = [["-serial", "stdio"], ["-cpu", "host"]]
-  shutdown_timeout = "1h"
+  shutdown_timeout = var.timeout
 }
 
 build {

--- a/ubuntu/Makefile
+++ b/ubuntu/Makefile
@@ -10,6 +10,7 @@ SERIES ?= jammy
 ARCH ?= amd64
 URL ?= http://releases.ubuntu.com
 SUMS ?= SHA256SUMS
+TIMEOUT ?= 1h
 
 ISO=$(shell wget -O- -q ${URL}/${SERIES}/${SUMS} | grep live-server | cut -d'*' -f2)
 
@@ -39,20 +40,23 @@ custom-cloudimg.tar.gz: check-deps clean
 	${PACKER} init . && ${PACKER} build \
 		-only='cloudimg.*' \
 		-var ubuntu_series=${SERIES} \
-		-var architecture=${ARCH} .
+		-var architecture=${ARCH} \
+		-var timeout=${TIMEOUT} .
 
 custom-ubuntu.tar.gz: check-deps clean seeds-flat.iso OVMF_VARS.fd \
 			packages/custom-packages.tar.gz
 	${PACKER} init . && ${PACKER} build -only=qemu.flat \
-	                -var ubuntu_series=${SERIES} \
-	                -var ubuntu_iso=${ISO} \
-			-var architecture=${ARCH} .
+	    -var ubuntu_series=${SERIES} \
+	    -var ubuntu_iso=${ISO} \
+	    -var architecture=${ARCH} \
+		-var timeout=${TIMEOUT} .
 
 custom-ubuntu-lvm.dd.gz: check-deps clean seeds-lvm.iso OVMF_VARS.fd
 	${PACKER} init . && ${PACKER} build -only=qemu.lvm \
-	                -var ubuntu_series=${SERIES} \
-	                -var ubuntu_lvm_iso=${ISO} \
-			-var architecture=${ARCH} .
+	    -var ubuntu_series=${SERIES} \
+	    -var ubuntu_lvm_iso=${ISO} \
+	    -var architecture=${ARCH} \
+		-var timeout=${TIMEOUT} .
 clean:
 	${RM} -rf output-* custom-*.gz \
 		seeds-flat.iso seeds-lvm.iso seeds-cloudimg.iso \

--- a/ubuntu/README.md
+++ b/ubuntu/README.md
@@ -158,6 +158,10 @@ The URL prefix for mirror that is hosting the ISO images for a given series. The
 
 The file name for the checksums file. The default value is set to SHA256SUMS.
 
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ### Default Username
 
 The default username is ```ubuntu```

--- a/ubuntu/ubuntu-cloudimg.pkr.hcl
+++ b/ubuntu/ubuntu-cloudimg.pkr.hcl
@@ -54,9 +54,9 @@ source "qemu" "cloudimg" {
   shutdown_command       = "sudo -S shutdown -P now"
   ssh_handshake_attempts = 500
   ssh_password           = var.ssh_password
-  ssh_timeout            = "45m"
+  ssh_timeout            = var.timeout
   ssh_username           = var.ssh_username
-  ssh_wait_timeout       = "45m"
+  ssh_wait_timeout       = var.timeout
   use_backing_file       = true
 }
 

--- a/ubuntu/ubuntu-cloudimg.variables.pkr.hcl
+++ b/ubuntu/ubuntu-cloudimg.variables.pkr.hcl
@@ -27,9 +27,3 @@ variable "architecture" {
   default     = "amd64"
   description = "The architecture to build the image for (amd64 or arm64)"
 }
-
-variable "timeout" {
-  type        = string
-  default     = "1h"
-  description = "The timeout for building an image"
-}

--- a/ubuntu/ubuntu-cloudimg.variables.pkr.hcl
+++ b/ubuntu/ubuntu-cloudimg.variables.pkr.hcl
@@ -27,3 +27,9 @@ variable "architecture" {
   default     = "amd64"
   description = "The architecture to build the image for (amd64 or arm64)"
 }
+
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "The timeout for building an image"
+}

--- a/ubuntu/ubuntu-flat.pkr.hcl
+++ b/ubuntu/ubuntu-flat.pkr.hcl
@@ -24,9 +24,9 @@ source "qemu" "flat" {
   shutdown_command       = "sudo -S shutdown -P now"
   ssh_handshake_attempts = 500
   ssh_password           = var.ssh_ubuntu_password
-  ssh_timeout            = "45m"
+  ssh_timeout            = var.timeout
   ssh_username           = "ubuntu"
-  ssh_wait_timeout       = "45m"
+  ssh_wait_timeout       = var.timeout
 }
 
 build {

--- a/ubuntu/ubuntu-lvm.pkr.hcl
+++ b/ubuntu/ubuntu-lvm.pkr.hcl
@@ -24,9 +24,9 @@ source "qemu" "lvm" {
   shutdown_command       = "sudo -S shutdown -P now"
   ssh_handshake_attempts = 500
   ssh_password           = var.ssh_ubuntu_password
-  ssh_timeout            = "45m"
+  ssh_timeout            = var.timeout
   ssh_username           = "ubuntu"
-  ssh_wait_timeout       = "45m"
+  ssh_wait_timeout       = var.timeout
 }
 
 build {

--- a/ubuntu/variables.pkr.hcl
+++ b/ubuntu/variables.pkr.hcl
@@ -48,3 +48,9 @@ variable "ssh_ubuntu_password" {
   type    = string
   default = "ubuntu"
 }
+
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}

--- a/vmware-esxi/Makefile
+++ b/vmware-esxi/Makefile
@@ -7,6 +7,7 @@ PACKER_LOG ?= 0
 export PACKER_LOG
 ISO ?= ${VMWARE_ESXI_ISO_PATH}
 VENV := .ve
+TIMEOUT ?= 1h
 
 .PHONY: all lint format clean
 
@@ -24,7 +25,7 @@ scripts.tar.xz:
 	tar cJf $@ --group=0 --owner=0 -C $${SCRIPT_DIR} .
 
 vmware-esxi.dd.gz: check-deps clean scripts.tar.xz
-	${PACKER} init vmware-esxi.pkr.hcl && ${PACKER} build -var "vmware_esxi_iso_path=${ISO}" vmware-esxi.pkr.hcl
+	${PACKER} init vmware-esxi.pkr.hcl && ${PACKER} build -var "vmware_esxi_iso_path=${ISO}" -var timeout=${TIMEOUT} vmware-esxi.pkr.hcl
 
 $(VENV): requirements-dev.txt requirements.txt
 	python3 -m venv --system-site-packages --clear $@

--- a/vmware-esxi/README.md
+++ b/vmware-esxi/README.md
@@ -58,6 +58,12 @@ Note: vmware-esxi.pkr.hcl is configured to run Packer in headless mode. Only Pac
 
 Installation is non-interactive.
 
+### Makefile Parameters
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
 ## Uploading an image to MAAS
 
 _Note: If using snap-based MAAS, the image to be uploaded needs reside under your home directory._

--- a/vmware-esxi/vmware-esxi.pkr.hcl
+++ b/vmware-esxi/vmware-esxi.pkr.hcl
@@ -13,6 +13,12 @@ variable "vmware_esxi_iso_path" {
   default = "${env("VMWARE_ESXI_ISO_PATH")}"
 }
 
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
 source "qemu" "esxi" {
   boot_command     = ["<enter><wait>", "<leftShift>O", " ks=cdrom:/KS.CFG", " cpuUniformityHardCheckPanic=FALSE", "systemMediaSize=min", " com1_Port=0x3f8 tty2Port=com1", "<enter>"]
   boot_wait        = "3s"
@@ -28,7 +34,7 @@ source "qemu" "esxi" {
   memory           = 4096
   net_device       = "vmxnet3"
   qemuargs         = [["-cpu", "host"], ["-smp", "2,sockets=2,cores=1,threads=1"], ["-serial", "stdio"]]
-  shutdown_timeout = "1h"
+  shutdown_timeout = var.timeout
 }
 
 build {


### PR DESCRIPTION
Expose the timeout option in as a variable in packer `-var timeout <value` or with make `TIMEOUT=<value>`, rather than hard-coding it.