### PR TITLE
Noble build fixes + More

### DIFF
--- a/ubuntu/Makefile
+++ b/ubuntu/Makefile
@@ -12,6 +12,12 @@ URL ?= http://releases.ubuntu.com
 SUMS ?= SHA256SUMS
 TIMEOUT ?= 1h
 
+ifeq ($(wildcard /usr/share/OVMF/OVMF_CODE.fd),)
+	OVMF_SFX ?= _4M
+else
+	OVMF_SFX ?=
+endif
+
 ISO=$(shell wget -O- -q ${URL}/${SERIES}/${SUMS} | grep live-server | cut -d'*' -f2)
 
 .PHONY: all clean
@@ -33,7 +39,7 @@ seeds-lvm.iso: user-data-lvm meta-data
 seeds-flat.iso: user-data-flat meta-data
 	cloud-localds $@ $^
 
-OVMF_VARS.fd: /usr/share/OVMF/OVMF_VARS.fd
+OVMF_VARS.fd: /usr/share/OVMF/OVMF_VARS*.fd
 	cp -v $< $@
 
 custom-cloudimg.tar.gz: check-deps clean
@@ -41,21 +47,24 @@ custom-cloudimg.tar.gz: check-deps clean
 		-only='cloudimg.*' \
 		-var ubuntu_series=${SERIES} \
 		-var architecture=${ARCH} \
+		-var ovmf_suffix=${OVMF_SFX} \
 		-var timeout=${TIMEOUT} .
 
 custom-ubuntu.tar.gz: check-deps clean seeds-flat.iso OVMF_VARS.fd \
 			packages/custom-packages.tar.gz
 	${PACKER} init . && ${PACKER} build -only=qemu.flat \
-	    -var ubuntu_series=${SERIES} \
-	    -var ubuntu_iso=${ISO} \
-	    -var architecture=${ARCH} \
+		-var ubuntu_series=${SERIES} \
+		-var ubuntu_iso=${ISO} \
+		-var architecture=${ARCH} \
+		-var ovmf_suffix=${OVMF_SFX} \
 		-var timeout=${TIMEOUT} .
 
 custom-ubuntu-lvm.dd.gz: check-deps clean seeds-lvm.iso OVMF_VARS.fd
 	${PACKER} init . && ${PACKER} build -only=qemu.lvm \
-	    -var ubuntu_series=${SERIES} \
-	    -var ubuntu_lvm_iso=${ISO} \
-	    -var architecture=${ARCH} \
+		-var ubuntu_series=${SERIES} \
+		-var ubuntu_lvm_iso=${ISO} \
+		-var architecture=${ARCH} \
+		-var ovmf_suffix=${OVMF_SFX} \
 		-var timeout=${TIMEOUT} .
 clean:
 	${RM} -rf output-* custom-*.gz \

--- a/ubuntu/README.md
+++ b/ubuntu/README.md
@@ -9,6 +9,7 @@ The Packer templates in this directory creates Ubuntu images for use with MAAS.
 * A machine running Ubuntu 18.04+ with the ability to run KVM virtual machines.
 * qemu-utils, libnbd-bin, nbdkit and fuse2fs
 * qemu-system
+* qemu-system-modules-spice (If building on Ubuntu 24.04 LTS "Noble")
 * ovmf
 * cloud-image-utils
 * parted

--- a/ubuntu/ubuntu-cloudimg.pkr.hcl
+++ b/ubuntu/ubuntu-cloudimg.pkr.hcl
@@ -46,7 +46,7 @@ source "qemu" "cloudimg" {
     ["-machine", "${lookup(local.qemu_machine, var.architecture, "")}"],
     ["-cpu", "${lookup(local.qemu_cpu, var.architecture, "")}"],
     ["-device", "virtio-gpu-pci"],
-    ["-drive", "if=pflash,format=raw,id=ovmf_code,readonly=on,file=/usr/share/${lookup(local.uefi_imp, var.architecture, "")}/${lookup(local.uefi_imp, var.architecture, "")}_CODE.fd"],
+    ["-drive", "if=pflash,format=raw,id=ovmf_code,readonly=on,file=/usr/share/${lookup(local.uefi_imp, var.architecture, "")}/${lookup(local.uefi_imp, var.architecture, "")}_CODE${var.ovmf_suffix}.fd"],
     ["-drive", "if=pflash,format=raw,id=ovmf_vars,file=${lookup(local.uefi_imp, var.architecture, "")}_VARS.fd"],
     ["-drive", "file=output-cloudimg/packer-cloudimg,format=qcow2"],
     ["-drive", "file=seeds-cloudimg.iso,format=raw"]

--- a/ubuntu/ubuntu-cloudimg.variables.pkr.hcl
+++ b/ubuntu/ubuntu-cloudimg.variables.pkr.hcl
@@ -27,3 +27,10 @@ variable "architecture" {
   default     = "amd64"
   description = "The architecture to build the image for (amd64 or arm64)"
 }
+
+variable "ovmf_suffix" {
+  type        = string
+  default     = ""
+  description = "Suffix for OVMF CODE and VARS files. Newer systems such as Noble use _4M."
+}
+

--- a/ubuntu/ubuntu-flat.pkr.hcl
+++ b/ubuntu/ubuntu-flat.pkr.hcl
@@ -15,8 +15,8 @@ source "qemu" "flat" {
     ["-device", "virtio-blk-pci,drive=drive0,bootindex=0"],
     ["-device", "virtio-blk-pci,drive=cdrom0,bootindex=1"],
     ["-device", "virtio-blk-pci,drive=drive1,bootindex=2"],
-    ["-drive", "if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE.fd"],
-    ["-drive", "if=pflash,format=raw,file=OVMF_VARS.fd"],
+    ["-drive", "if=pflash,format=raw,id=ovmf_code,readonly=on,file=/usr/share/${lookup(local.uefi_imp, var.architecture, "")}/${lookup(local.uefi_imp, var.architecture, "")}_CODE${var.ovmf_suffix}.fd"],
+    ["-drive", "if=pflash,format=raw,id=ovmf_vars,file=${lookup(local.uefi_imp, var.architecture, "")}_VARS.fd"],
     ["-drive", "file=output-flat/packer-flat,if=none,id=drive0,cache=writeback,discard=ignore,format=raw"],
     ["-drive", "file=seeds-flat.iso,format=raw,cache=none,if=none,id=drive1,readonly=on"],
     ["-drive", "file=packer_cache/${var.ubuntu_series}.iso,if=none,id=cdrom0,media=cdrom"]

--- a/ubuntu/ubuntu-flat.variables.pkr.hcl
+++ b/ubuntu/ubuntu-flat.variables.pkr.hcl
@@ -6,7 +6,7 @@ variable "flat_filename" {
 
 variable "ubuntu_iso" {
   type        = string
-  default     = "ubuntu-22.04.3-live-server-amd64.iso"
+  default     = "ubuntu-22.04.4-live-server-amd64.iso"
   description = "The ISO name to build the image from"
 }
 

--- a/ubuntu/ubuntu-lvm.pkr.hcl
+++ b/ubuntu/ubuntu-lvm.pkr.hcl
@@ -15,8 +15,8 @@ source "qemu" "lvm" {
     ["-device", "virtio-blk-pci,drive=drive0,bootindex=0"],
     ["-device", "virtio-blk-pci,drive=cdrom0,bootindex=1"],
     ["-device", "virtio-blk-pci,drive=drive1,bootindex=2"],
-    ["-drive", "if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE.fd"],
-    ["-drive", "if=pflash,format=raw,file=OVMF_VARS.fd"],
+    ["-drive", "if=pflash,format=raw,id=ovmf_code,readonly=on,file=/usr/share/${lookup(local.uefi_imp, var.architecture, "")}/${lookup(local.uefi_imp, var.architecture, "")}_CODE${var.ovmf_suffix}.fd"],
+    ["-drive", "if=pflash,format=raw,id=ovmf_vars,file=${lookup(local.uefi_imp, var.architecture, "")}_VARS.fd"],
     ["-drive", "file=output-lvm/packer-lvm,if=none,id=drive0,cache=writeback,discard=ignore,format=raw"],
     ["-drive", "file=seeds-lvm.iso,format=raw,cache=none,if=none,id=drive1,readonly=on"],
     ["-drive", "file=packer_cache/${var.ubuntu_series}.iso,if=none,id=cdrom0,media=cdrom"]

--- a/ubuntu/ubuntu-lvm.variables.pkr.hcl
+++ b/ubuntu/ubuntu-lvm.variables.pkr.hcl
@@ -1,6 +1,6 @@
 variable "ubuntu_lvm_iso" {
   type        = string
-  default     = "ubuntu-22.04.3-live-server-amd64.iso"
+  default     = "ubuntu-22.04.4-live-server-amd64.iso"
   description = "The ISO name to build the image from"
 }
 


### PR DESCRIPTION
- Add support for building images on Noble
- Update default Jammy ISO version to 22.04.4
- Minor space / tabe clean-ups