### PR TITLE
Fix custom package path resolution in install-custom-packages script

### DIFF
--- a/ubuntu/scripts/install-custom-packages
+++ b/ubuntu/scripts/install-custom-packages
@@ -20,7 +20,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 export DEBIAN_FRONTEND=noninteractive
 
-PKG_TGZ="/curtin/custom-packages.tar.gz"
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+PKG_TGZ="${SCRIPT_DIR}/custom-packages.tar.gz"
 
 if [ ! -f "${PKG_TGZ}" ]; then
     exit 0


### PR DESCRIPTION
Fix custom package path resolution in install-custom-packages script

- Changed PKG_TGZ path to be dynamically resolved based on the script's directory.
- This ensures that the custom-packages.tar.gz file is correctly located relative to the script's location