### PR TITLE
Update for minimal hardware requirement for ESXI 8.0

### DIFF
--- a/vmware-esxi/vmware-esxi.pkr.hcl
+++ b/vmware-esxi/vmware-esxi.pkr.hcl
@@ -31,7 +31,7 @@ source "qemu" "esxi" {
   headless         = true
   iso_checksum     = "none"
   iso_url          = var.vmware_esxi_iso_path
-  memory           = 4096
+  memory           = 8192
   net_device       = "vmxnet3"
   qemuargs         = [["-cpu", "host"], ["-smp", "2,sockets=2,cores=1,threads=1"], ["-serial", "stdio"], ["-enable-kvm"]]
   shutdown_timeout = var.timeout


### PR DESCRIPTION
As indicated in the [VMware documentation](https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-esxi-installation/GUID-DEB8086A-306B-4239-BF76-E354679202FC.html#:~:text=ESXi%208.0%20requires%20a%20minimum,Gigabit%20or%20faster%20Ethernet%20controllers), the minimum memory requirement is 8GB for ESXI 8.0.