### PR TITLE
New SLES 15 Fixes and Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Read more about how [custom images](https://maas.io/docs/how-to-customise-images
 | Rocky 8         | Beta               | >= 3.3           |
 | Rocky 9         | Beta               | >= 3.3           |
 | SLES 12         | Beta               | >= 3.4           |
-| SLES 15         | Beta               | >= 3.4           |
+| SLES 15         | Beta               | >= 3.3           |
 | Ubuntu          | Stable             | >= 3.0           |
 | VMWare ESXi 6   | EOL                | >= 3.0           |
 | VMWare ESXi 7   | Stable             | >= 3.0           |

--- a/sles15/http/sles15.xml
+++ b/sles15/http/sles15.xml
@@ -180,6 +180,9 @@
             <package>tar</package>
             <package>wget</package>
             <package>xfsprogs</package>
+            <package>grub2-i386-pc</package>
+            <package>grub2-x86_64-efi</package>
+            <package>grub2-branding-SLE</package>
         </packages>
         <patterns config:type="list">
             <pattern>base</pattern>


### PR DESCRIPTION
fix SLES 15 SP6 Deployment issues due to
missing grub-efi package.

Set SLES 15 supported MAAS version to 3.3 as
there is code in place to support that.