### PR TITLE
Fix ubuntu kernel installation failures

### DIFF
--- a/ubuntu/scripts/setup-bootloader
+++ b/ubuntu/scripts/setup-bootloader
@@ -4,7 +4,7 @@
 #
 # Author: Alexsander de Souza <alexsander.souza@canonical.com>
 #
-# Copyright (C) 2023 Canonical
+# Copyright (C) 2024 Canonical
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -25,6 +25,8 @@ export DEBIAN_FRONTEND=noninteractive
 rm /var/cache/debconf/config.dat
 dpkg --configure -a
 
+# Update the package lists before attempting to install the kernel
+apt-get update
 # Ensure the existence of linux-image-generic for non-cloudimg images.
 apt-get -y install linux-image-generic
 


### PR DESCRIPTION
ubuntu/scripts/setup-bootloader:

- update package lists before attempting to install the kernel.

- This ensures images built a while back do no fail to install the kernel due to outdated lists.

- updated copyright year to 2024.