### PR TITLE
Use host CPU qemu parameter to prevent CPU Apic ID - 00000000 error

### DIFF
--- a/windows/windows.pkr.hcl
+++ b/windows/windows.pkr.hcl
@@ -49,6 +49,7 @@ source "qemu" "windows_builder" {
   cpus             = "2"
   net_device       = "e1000"
   qemuargs         = [
+    ["-cpu", "host"],
     ["-serial", "stdio"],
     ["-drive", "if=pflash,format=raw,id=ovmf_code,readonly=on,file=/usr/share/OVMF/OVMF_CODE${var.ovmf_suffix}.fd"],
     ["-drive", "if=pflash,format=raw,id=ovmf_vars,file=OVMF_VARS.fd"],


### PR DESCRIPTION
Use host CPU qemu parameter to prevent CPU Apic ID - 00000000 error.

fixes #252