### PR TITLE
Windows README has the wrong filetype

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -113,6 +113,6 @@ maas admin boot-resources create \
     name='windows/windows-server' \
     title='Windows Server' \
     architecture='amd64/generic' \
-    filetype='ddtgz' \
+    filetype='ddgz' \
     content@=windows-server-amd64-root-dd.gz
 ```


### PR DESCRIPTION
The windows readme has specified an incorrect filetype for the maas image.

This leads to deployment failures