### PR TITLE
fix missing ovmf file for debian image generation

### DIFF
--- a/debian/Makefile
+++ b/debian/Makefile
@@ -26,6 +26,12 @@ ifeq ($(strip $(ARCH)),arm64)
 	boot = uefi
 endif
 
+ifeq ($(wildcard /usr/share/OVMF/OVMF_CODE.fd),)
+	OVMF_SFX ?= _4M
+else
+	OVMF_SFX ?=
+endif
+
 .PHONY: all clean
 
 all: debian
@@ -47,6 +53,7 @@ debian: check-deps clean
 		-var debian_series=${SERIES} \
 		-var debian_version=${VERSION} \
 		-var architecture=${ARCH} \
+		-var ovmf_suffix=${OVMF_SFX} \
 		-var boot_mode=${BOOT} \
 		-var timeout=${TIMEOUT} .
 

--- a/debian/debian-cloudimg.pkr.hcl
+++ b/debian/debian-cloudimg.pkr.hcl
@@ -46,7 +46,7 @@ source "qemu" "cloudimg" {
     ["-machine", "${lookup(local.qemu_machine, var.architecture, "")}"],
     ["-cpu", "${lookup(local.qemu_cpu, var.architecture, "")}"],
     ["-device", "virtio-gpu-pci"],
-    ["-drive", "if=pflash,format=raw,id=ovmf_code,readonly=on,file=/usr/share/${lookup(local.uefi_imp, var.architecture, "")}/${lookup(local.uefi_imp, var.architecture, "")}_CODE.fd"],
+    ["-drive", "if=pflash,format=raw,id=ovmf_code,readonly=on,file=/usr/share/${lookup(local.uefi_imp, var.architecture, "")}/${lookup(local.uefi_imp, var.architecture, "")}_CODE${var.ovmf_suffix}.fd"],
     ["-drive", "if=pflash,format=raw,id=ovmf_vars,file=${lookup(local.uefi_imp, var.architecture, "")}_VARS.fd"],
     ["-drive", "file=output-cloudimg/packer-cloudimg,format=qcow2"],
     ["-drive", "file=seeds-cloudimg.iso,format=raw"]
@@ -66,7 +66,7 @@ build {
 
   provisioner "shell-local" {
     inline = [
-      "cp /usr/share/${lookup(local.uefi_imp, var.architecture, "")}/${lookup(local.uefi_imp, var.architecture, "")}_VARS.fd ${lookup(local.uefi_imp, var.architecture, "")}_VARS.fd",
+      "cp /usr/share/${lookup(local.uefi_imp, var.architecture, "")}/${lookup(local.uefi_imp, var.architecture, "")}_VARS${var.ovmf_suffix}.fd ${lookup(local.uefi_imp, var.architecture, "")}_VARS.fd",
       "cloud-localds seeds-cloudimg.iso user-data-cloudimg meta-data"
     ]
     inline_shebang = "/bin/bash -e"

--- a/debian/debian-cloudimg.variables.pkr.hcl
+++ b/debian/debian-cloudimg.variables.pkr.hcl
@@ -39,3 +39,9 @@ variable "architecture" {
   default     = "amd64"
   description = "The architecture to build the image for (amd64 or arm64)"
 }
+
+variable "ovmf_suffix" {
+  type        = string
+  default     = ""
+  description = "Suffix for OVMF CODE and VARS files. Newer systems such as Noble use _4M."
+}


### PR DESCRIPTION
on ubuntu noble onwards, _4M ovmf image is now the default one and the OVMF_CODE.fd has been removed.