### PR TITLE
Predictable Windows Recovery Partition

### DIFF
--- a/windows/http/Autounattend.xml.ISO.template
+++ b/windows/http/Autounattend.xml.ISO.template
@@ -17,8 +17,13 @@
                             <Type>MSR</Type>
                         </CreatePartition>
                         <CreatePartition wcm:action="add">
-                            <Extend>true</Extend>
                             <Order>3</Order>
+                            <Type>Primary</Type>
+                            <Size>768</Size>
+                        </CreatePartition>
+                        <CreatePartition wcm:action="add">
+                            <Order>4</Order>
+                            <Extend>true</Extend>
                             <Type>Primary</Type>
                         </CreatePartition>
                     </CreatePartitions>
@@ -30,9 +35,16 @@
                             <PartitionID>1</PartitionID>
                         </ModifyPartition>
                         <ModifyPartition wcm:action="add">
+                            <Label>WinRE</Label>
                             <Format>NTFS</Format>
                             <Order>2</Order>
+                            <TypeID>DE94BBA4-06D1-4D40-A16A-BFD50179D6AC</TypeID>
                             <PartitionID>3</PartitionID>
+                        </ModifyPartition>
+                        <ModifyPartition wcm:action="add">
+                            <Format>NTFS</Format>
+                            <Order>3</Order>
+                            <PartitionID>4</PartitionID>
                             <Label>System</Label>
                         </ModifyPartition>
                     </ModifyPartitions>
@@ -43,7 +55,7 @@
             <ImageInstall>
                 <OSImage>
                     <InstallTo>
-                        <PartitionID>3</PartitionID>
+                        <PartitionID>4</PartitionID>
                         <DiskID>0</DiskID>
                     </InstallTo>
                     <InstallToAvailablePartition>false</InstallToAvailablePartition>

--- a/windows/windows.pkr.hcl
+++ b/windows/windows.pkr.hcl
@@ -105,7 +105,7 @@ build {
       "source scripts/setup-nbd",
       "TMP_DIR=$(mktemp -d /tmp/packer-maas-XXXX)",
       "echo 'Adding curtin-hooks to image...'",
-      "mount -t ntfs $${nbd}p3 $TMP_DIR",
+      "mount -t ntfs $${nbd}p4 $TMP_DIR",
       "mkdir -p $TMP_DIR/curtin",
       "cp ./curtin/* $TMP_DIR/curtin/",
       "sync -f $TMP_DIR/curtin",


### PR DESCRIPTION
Make Windows Recovery partition creation more predictable.

This ensures the recovery partition is always created before the OS partition and does not block expansion of the OS partition to the full extent.

Has been Tested with:

- Windows Server 2016
- Windows Server 2019
- Windows Server 2022
- Windows Server 2025
- Windows 11