### PR TITLE
Add aarch64 support to RHEL9 template

### DIFF
--- a/rhel9/Makefile
+++ b/rhel9/Makefile
@@ -4,10 +4,22 @@ include ../scripts/check.mk
 
 PACKER ?= packer
 PACKER_LOG ?= 0
-ISO ?= rhel-baseos-9.1-x86_64-dvd.iso
+ISO ?= rhel-baseos-9.0-x86_64-dvd.iso
 TIMEOUT ?= 1h
+ARCH ?= x86_64
+
+ifeq ($(wildcard /usr/share/OVMF/OVMF_CODE.fd),)
+	OVMF_SFX ?= _4M
+else
+	OVMF_SFX ?=
+endif
 
 export PACKER_LOG
+
+# Fallback
+ifeq ($(strip $(ARCH)),amd64)
+	ARCH = x86_64
+endif
 
 .PHONY: all clean
 
@@ -15,8 +27,30 @@ all: rhel9.tar.gz
 
 $(eval $(call check_packages_deps))
 
-rhel9.tar.gz: check-deps clean
-	${PACKER} init rhel9.pkr.hcl && ${PACKER} build -var "rhel9_iso_path=${ISO}" -var timeout=${TIMEOUT} rhel9.pkr.hcl
+lint:
+	packer validate .
+	packer fmt -check -diff .
+
+format:
+	packer fmt .
+
+OVMF_VARS.fd: /usr/share/OVMF/OVMF_VARS${OVMF_SFX}.fd
+	cp -v $< ${ARCH}_VARS.fd
+
+SIZE_VARS.fd:
+ifeq ($(strip $(ARCH)),aarch64)
+	truncate -s 64m ${ARCH}_VARS.fd
+else
+	truncate -s 2m ${ARCH}_VARS.fd
+endif
+
+rhel9.tar.gz: check-deps clean OVMF_VARS.fd SIZE_VARS.fd
+	${PACKER} init rhel9.pkr.hcl && ${PACKER} build \
+							-var architecture=${ARCH} \
+							-var ovmf_suffix=${OVMF_SFX} \
+							-var "rhel9_iso_path=${ISO}" \
+							-var timeout=${TIMEOUT} \
+							rhel9.pkr.hcl
 
 clean:
-	${RM} -rf output-rhel9 rhel9.tar.gz
+	${RM} -rf *.fd output-rhel9 rhel9.tar.gz

--- a/rhel9/README.md
+++ b/rhel9/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The Packer template in this directory creates a RHEL 9 AMD64 image for use with MAAS.
+The Packer template in this directory creates a RHEL 9 AMD64/ARM64 image for use with MAAS.
 
 ## Prerequisites (to create the image)
 
@@ -18,7 +18,7 @@ The Packer template in this directory creates a RHEL 9 AMD64 image for use with 
 
 ## Customizing the Image
 
-The deployment image may be customized by modifying http/rhel9.ks. See the [CentOS kickstart documentation](https://docs.centos.org/en-US/centos/install-guide/Kickstart2/) for more information.
+The deployment image may be customized by modifying http/rhel9.ks.pkrtpl.hcl. See the [CentOS kickstart documentation](https://docs.centos.org/en-US/centos/install-guide/Kickstart2/) for more information.
 
 ## Building the image using a proxy
 
@@ -35,7 +35,7 @@ export KS_PROXY=$HTTP_PROXY
 You can easily build the image using the Makefile:
 
 ```shell
-make ISO=/PATH/TO/rhel-baseos-9.1-x86_64-dvd.iso
+make ISO=/PATH/TO/rhel-baseos-9.0-x86_64-dvd.iso
 ```
 
 Alternatively you can manually run packer. Your current working directory must
@@ -44,7 +44,7 @@ you can generate an image with:
 
 ```shell
 packer init
-PACKER_LOG=1 packer build -var 'rhel9_iso_path=/PATH/TO/rhel-baseos-9.1-x86_64-dvd.iso' .
+PACKER_LOG=1 packer build -var 'rhel9_iso_path=/PATH/TO/rhel-baseos-9.0-x86_64-dvd.iso' .
 ```
 
 Note: rhel9.pkr.hcl is configured to run Packer in headless mode. Only Packer
@@ -56,6 +56,14 @@ Installation is non-interactive.
 
 ### Makefile Parameters
 
+#### ARCH
+
+Defaults to x86_64 to build AMD64 compatible images. In order to build ARM64 images, use ARCH=aarch64
+
+### ISO
+
+The path to the installation ISO image for RHEL.
+
 #### TIMEOUT
 
 The timeout to apply when building the image. The default value is set to 1h.
@@ -64,10 +72,38 @@ The timeout to apply when building the image. The default value is set to 1h.
 
 ```shell
 maas $PROFILE boot-resources create \
-    name='rhel/9-custom' title='RHEL 9 Custom' \
+    name='rhel/rhel9' title='RHEL 9 Custom' \
     architecture='amd64/generic' filetype='tgz' \
     content@=rhel9.tar.gz
 ```
+
+For ARM64, use:
+
+```shell
+maas $PROFILE boot-resources create \
+    name='rhel/rhel9' title='RHEL 9 Custom' \
+    architecture='arm64/generic' filetype='tgz' \
+    content@=rhel9.tar.gz
+```
+
+Please note that, currently due to lack of support in curtin, deploying ARM64 images needs a preseed file. This is due to [LP# 2090874](https://bugs.launchpad.net/curtin/+bug/2090874) and currently is in the process of getting fixed.
+
+```
+#cloud-config
+debconf_selections:
+ maas: |
+  {{for line in str(curtin_preseed).splitlines()}}
+  {{line}}
+  {{endfor}}
+  
+extract_commands:
+  grub_install: curtin in-target -- cp -v /boot/efi/EFI/redhat/shimaa64.efi /boot/efi/EFI/redhat/shimx64.efi
+
+late_commands:
+  maas: [wget, '--no-proxy', '{{node_disable_pxe_url}}', '--post-data', '{{node_disable_pxe_data}}', '-O', '/dev/null']
+```
+
+This file needs to be saved on Region Controllers under /var/snap/maas/current/preseeds/curtin_userdata_rhel_arm64_generic_rhel9 or /etc/maas/preseeds/curtin_userdata_rhel_arm64_generic_rhel9. The last portion of this file must match the image name uploaded in MAAS.
 
 ## Default Username
 

--- a/rhel9/http/rhel9.ks.pkrtpl.hcl
+++ b/rhel9/http/rhel9.ks.pkrtpl.hcl
@@ -1,19 +1,21 @@
-cdrom
+#cdrom
+harddrive --partition=vdb --dir=/
 poweroff
+eula --agreed
 firewall --enabled --service=ssh
 firstboot --disable
-ignoredisk --only-use=vda
 lang en_US.UTF-8
 keyboard us
 network --device eth0 --bootproto=dhcp
 firewall --enabled --service=ssh
 selinux --enforcing
-timezone UTC --isUtc
-bootloader --location=mbr --driveorder="vda" --timeout=1
+timezone UTC --utc
 rootpw --plaintext password
 
 repo --name="AppStream" ${KS_APPSTREAM_REPOS} ${KS_PROXY}
 
+ignoredisk --only-use=vda
+bootloader --disabled
 zerombr
 clearpart --all --initlabel
 part / --size=1 --grow --asprimary --fstype=ext4
@@ -44,7 +46,7 @@ sed -i 's/GRUB_ENABLE_BLSCFG=.*/GRUB_ENABLE_BLSCFG=false/g' /etc/default/grub
 dnf clean all
 %end
 
-%packages
+%packages --ignoremissing
 @core
 bash-completion
 cloud-init
@@ -56,9 +58,11 @@ tar
 # grub2-efi-x64 ships grub signed for UEFI secure boot. If grub2-efi-x64-modules
 # is installed grub will be generated on deployment and unsigned which breaks
 # UEFI secure boot.
-grub2-efi-x64
+grub2-pc
+grub2-efi-*
+shim-*
+grub2-efi-*-modules
 efibootmgr
-shim-x64
 dosfstools
 lvm2
 mdadm

--- a/rhel9/rhel9.pkr.hcl
+++ b/rhel9/rhel9.pkr.hcl
@@ -36,20 +36,72 @@ variable "timeout" {
   description = "Timeout for building the image"
 }
 
-locals {
-  ks_proxy = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
+variable "architecture" {
+  type        = string
+  default     = "amd64"
+  description = "The architecture to build the image for (amd64 or arm64)"
 }
 
+variable "ovmf_suffix" {
+  type        = string
+  default     = ""
+  description = "Suffix for OVMF CODE and VARS files. Newer systems such as Noble use _4M."
+}
+
+locals {
+  qemu_arch = {
+    "x86_64"  = "x86_64"
+    "aarch64" = "aarch64"
+  }
+  uefi_imp = {
+    "x86_64"  = "OVMF"
+    "aarch64" = "AAVMF"
+  }
+  uefi_sfx = {
+    "x86_64"  = "${var.ovmf_suffix}"
+    "aarch64" = ""
+  }
+  qemu_machine = {
+    "x86_64"  = "accel=kvm"
+    "aarch64" = "virt"
+  }
+  qemu_cpu = {
+    "x86_64"  = "host"
+    "aarch64" = "max"
+  }
+  ks_proxy    = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
+}
+
+
 source "qemu" "rhel9" {
-  boot_command     = ["<up><tab> ", "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/rhel9.ks ", "console=ttyS0 inst.cmdline", "<enter>"]
-  boot_wait        = "3s"
+  boot_command     = ["<up><wait>", "e", "<down><down><down><left>", " console=ttyS0 inst.cmdline inst.text inst.ks=http://{{.HTTPIP}}:{{.HTTPPort}}/rhel9.ks <f10>"]
+  boot_wait        = "5s"
   communicator     = "none"
   disk_size        = "4G"
   headless         = true
   iso_checksum     = "none"
   iso_url          = var.rhel9_iso_path
   memory           = 2048
-  qemuargs         = [["-serial", "stdio"], ["-cpu", "host"]]
+  cores            = 4
+  qemu_binary      = "qemu-system-${lookup(local.qemu_arch, var.architecture, "")}"
+  qemuargs = [
+    ["-serial", "stdio"],
+    ["-boot", "strict=off"],
+    ["-device", "qemu-xhci"],
+    ["-device", "usb-kbd"],
+    ["-device", "virtio-net-pci,netdev=net0"],
+    ["-netdev", "user,id=net0"],
+    ["-device", "virtio-blk-pci,drive=drive0,bootindex=0"],
+    ["-device", "virtio-blk-pci,drive=cdrom0,bootindex=1"],
+    ["-machine", "${lookup(local.qemu_machine, var.architecture, "")}"],
+    ["-cpu", "${lookup(local.qemu_cpu, var.architecture, "")}"],
+    ["-device", "virtio-gpu-pci"],
+    ["-global", "driver=cfi.pflash01,property=secure,value=off"],
+    ["-drive", "if=pflash,format=raw,unit=0,id=ovmf_code,readonly=on,file=/usr/share/${lookup(local.uefi_imp, var.architecture, "")}/${lookup(local.uefi_imp, var.architecture, "")}_CODE${lookup(local.uefi_sfx, var.architecture, "")}.fd"],
+    ["-drive", "if=pflash,format=raw,unit=1,id=ovmf_vars,file=${var.architecture}_VARS.fd"],
+    ["-drive", "file=output-rhel9/packer-rhel9,if=none,id=drive0,cache=writeback,discard=ignore,format=qcow2"],
+    ["-drive", "file=${var.rhel9_iso_path},if=none,id=cdrom0,media=cdrom"]
+  ]
   shutdown_timeout = var.timeout
   http_content = {
     "/rhel9.ks" = templatefile("${path.root}/http/rhel9.ks.pkrtpl.hcl",
@@ -59,7 +111,6 @@ source "qemu" "rhel9" {
       }
     )
   }
-
 }
 
 build {


### PR DESCRIPTION
The updated RHEL9 packer-maas template to support aarch64 builds and deployments.