### PR TITLE
New Debian Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Read more about how [custom images](https://maas.io/docs/how-to-customise-images
 | CentOS 8        | EOL                | >= 2.7           |
 | CentOS 8 Stream | Beta               | >= 3.2           |
 | CentOS 9 Stream | Beta               | >= 3.2           |
-| Debian 10       | Beta               | >= 3.3           |
-| Debian 11       | Beta               | >= 3.3           |
-| Debian 12       | Beta               | >= 3.3           |
+| Debian 10       | Beta               | >= 3.2           |
+| Debian 11       | Beta               | >= 3.2           |
+| Debian 12       | Beta               | >= 3.2           |
 | OL8             | Alpha              | >= 3.5           |
 | OL9             | Alpha              | >= 3.5           |
 | RHEL 7          | EOL                | >= 2.3           |

--- a/debian/README.md
+++ b/debian/README.md
@@ -142,7 +142,7 @@ The default username is ```debian```
 TGZ image
 
 ```shell
-maas admin boot-resources create \
+maas $PROFILE boot-resources create \
     name='custom/debian-12' \
     title='Debian 12 Custom' \
     architecture='amd64/generic' \

--- a/debian/scripts/networking.sh
+++ b/debian/scripts/networking.sh
@@ -67,11 +67,11 @@ chmod 755 /usr/local/bin/netplan
 
 # Bookworm LP#2011454
 if [ ${DEBIAN_VERSION} == '12' ]; then
-     wget http://archive.ubuntu.com/ubuntu/pool/main/c/cloud-init/cloud-init_23.1.2-0ubuntu0~23.04.1_all.deb
+     wget https://launchpad.net/~ubuntu-security/+archive/ubuntu/ubuntu-security-collab/+build/26002103/+files/cloud-init_23.1.2-0ubuntu0~23.04.1_all.deb
      dpkg -i cloud-init_23.1.2-0ubuntu0~23.04.1_all.deb
      rm cloud-init_23.1.2-0ubuntu0~23.04.1_all.deb
 else
-    wget http://archive.ubuntu.com/ubuntu/pool/main/c/cloud-init/cloud-init_20.1-10-g71af48df-0ubuntu5_all.deb
+    wget https://launchpad.net/ubuntu/+source/cloud-init/20.1-10-g71af48df-0ubuntu5/+build/19168684/+files/cloud-init_20.1-10-g71af48df-0ubuntu5_all.deb
     dpkg -i cloud-init_20.1-10-g71af48df-0ubuntu5_all.deb
     rm cloud-init_20.1-10-g71af48df-0ubuntu5_all.deb
 fi


### PR DESCRIPTION
Debian Updates:
- Lower MAAS requirement to 3.2
- Minor README update
- Switch to persistent links for required cloud-init packages