### PR TITLE
Added VMWare ESXi 9.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Read more about how [custom images](https://maas.io/docs/how-to-customise-images
 | [VMWare ESXi 6](vmware-esxi/README.md)     | EOL                | x86_64            | >= 3.0           |
 | [VMWare ESXi 7](vmware-esxi/README.md)     | Stable             | x86_64            | >= 3.0           |
 | [VMWare ESXi 8](vmware-esxi/README.md)     | Beta               | x86_64            | >= 3.0           |
+| [VMWare ESXi 9](vmware-esxi/README.md)     | Beta               | x86_64            | >= 3.0           |
 | [Windows 2016](windows/README.md)      | Beta               | x86_64            | >= 3.3           |
 | [Windows 2019](windows/README.md)      | Beta               | x86_64            | >= 3.3           |
 | [Windows 2022](windows/README.md)      | Beta               | x86_64            | >= 3.3           |

--- a/vmware-esxi/KS.CFG
+++ b/vmware-esxi/KS.CFG
@@ -13,7 +13,9 @@ install --firstdisk --ignoreprereqwarnings --ignoreprereqerrors --forceunsupport
 
 network --bootproto=dhcp
 
+
 %post --interpreter=busybox
+
 # The install reboots by default, when creating an image halt so Packer can
 # run post-processors and finish.
 halt

--- a/vmware-esxi/Makefile
+++ b/vmware-esxi/Makefile
@@ -24,7 +24,7 @@ scripts.tar.xz:
 	find $${SCRIPT_DIR} -name __pycache__ -type d -or -name *.so | xargs rm -rf ;\
 	tar cJf $@ --group=0 --owner=0 -C $${SCRIPT_DIR} .
 
-vmware-esxi.dd.gz: check-deps clean scripts.tar.xz
+vmware-esxi.dd.gz: check-deps clean usb.img scripts.tar.xz
 	${PACKER} init vmware-esxi.pkr.hcl && ${PACKER} build -var "vmware_esxi_iso_path=${ISO}" -var timeout=${TIMEOUT} vmware-esxi.pkr.hcl
 
 $(VENV): requirements-dev.txt requirements.txt
@@ -42,8 +42,15 @@ format: $(VENV)
 	$(VENV)/bin/isort $(py_files)
 	$(VENV)/bin/black -q $(py_files)
 
+usb.img:
+	dd if=/dev/zero of=usb.img bs=1M count=32
+	parted usb.img --script mklabel msdos
+	parted usb.img --script mkpart primary fat32 1MiB 100%
+	mformat -i usb.img@@1M ::
+	mcopy -i usb.img@@1M KS.CFG ::
+
 clean:
 	${RM} -rf output-esxi vmware-esxi.dd vmware-esxi.dd.gz \
-		scripts.tar.xz $(VENV)
+		scripts.tar.xz usb.img $(VENV)
 
 .INTERMEDIATE: scripts.tar.xz

--- a/vmware-esxi/maas/netplan-esxi
+++ b/vmware-esxi/maas/netplan-esxi
@@ -4,7 +4,7 @@
 #
 # Author: Lee Trager <lee.trager@canonical.com>
 #
-# Copyright (C) 2019 Canonical
+# Copyright (C) 2019-2025 Canonical
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -310,8 +310,6 @@ def _apply_subnets(config, vswitch, counters):
                     str(ip_net.netmask),
                 ]
                 gateway = subnet.get("gateway")
-                if gateway:
-                    cmd += ["-g", gateway]
                 check_call(cmd)
                 if gateway:
                     check_call(


### PR DESCRIPTION
Added VMWare ESXi 9.0 support:

- Reworked the build system to use USB based kick start file loading.
- Minor Netplan changes to make it compatible with 9.0
- Tested backward compatibility with 7.0 and 8.0