### PR TITLE
fix example upload command for Windows image

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -136,6 +136,6 @@ maas admin boot-resources create \
     name='windows/windows-server' \
     title='Windows Server' \
     architecture='amd64/generic' \
-    filetype='ddtgz' \
-    content@=windows-server-amd64-root-dd.gz
+    filetype='ddgz' \
+    content@=windows.dd.gz
 ```


### PR DESCRIPTION
```
maas admin boot-resources create \
    name='windows/windows-server' \
    title='Windows Server' \
    architecture='amd64/generic' \
    filetype='ddtgz' \
    content@=windows-server-amd64-root-dd.gz
```

The existing command has two errors:

1. Filetype `ddtgz` creates an unbootable image. It should instead be `ddgz`.
2. The default gzip filename is now `windows.dd.gz`.
