### PR TITLE
add mtools as required dependency for building ESXi images

### DIFF
--- a/vmware-esxi/Makefile
+++ b/vmware-esxi/Makefile
@@ -13,7 +13,7 @@ TIMEOUT ?= 1h
 
 all: vmware-esxi.dd.gz
 
-$(eval $(call check_packages_deps,fusefat,fusefat ))
+$(eval $(call check_packages_deps,fusefat,fusefat,mstools ))
 
 scripts.tar.xz:
 	export TMP_DIR=$$(mktemp -d /tmp/packer-maas-XXXX);\

--- a/vmware-esxi/Makefile
+++ b/vmware-esxi/Makefile
@@ -13,7 +13,7 @@ TIMEOUT ?= 1h
 
 all: vmware-esxi.dd.gz
 
-$(eval $(call check_packages_deps,fusefat,fusefat,mstools ))
+$(eval $(call check_packages_deps,fusefat mtools,fusefat))
 
 scripts.tar.xz:
 	export TMP_DIR=$$(mktemp -d /tmp/packer-maas-XXXX);\

--- a/vmware-esxi/README.md
+++ b/vmware-esxi/README.md
@@ -18,6 +18,7 @@
 * libosinfo-bin
 * libvirt-daemon
 * libvirt-daemon-system
+* mtools
 * nbdfuse
 * nbdkit
 * ovmf
@@ -37,8 +38,8 @@ VMware ESXi has a specific set of [hardware requirements](https://www.vmware.com
 
 ## Customizing the Image
 
-The deployment image may be customized by modifying packer-maas/vmware-esxi/KS.CFG see Installation and Upgrade Scripts in the [VMware ESXi installation and Setup manual](https://docs.vmware.com/en/VMware-vSphere/6.7/vsphere-esxi-67-installation-setup-guide.pdf) for more information.
-
+The deployment image may be customized by modifying packer-maas/vmware-esxi/KS.CFG see Installation and Upgrade Scripts in the [VMware ESXi installation and Setup manual](https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/esxi-installation-and-setup-8-0/installing-and-setting-up-esxi-install/installing-esxi-install/installing-esxi-by-using-a-script-install/installation-and-upgrade-scripts-used-for-esxi-installation-install.html) for more information.
+                               
 ## Building an image
 
 You can easily build the image using the Makefile:

--- a/vmware-esxi/README.md
+++ b/vmware-esxi/README.md
@@ -39,7 +39,7 @@ VMware ESXi has a specific set of [hardware requirements](https://www.vmware.com
 ## Customizing the Image
 
 The deployment image may be customized by modifying packer-maas/vmware-esxi/KS.CFG see Installation and Upgrade Scripts in the [VMware ESXi installation and Setup manual](https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/esxi-installation-and-setup-8-0/installing-and-setting-up-esxi-install/installing-esxi-install/installing-esxi-by-using-a-script-install/installation-and-upgrade-scripts-used-for-esxi-installation-install.html) for more information.
-                               
+
 ## Building an image
 
 You can easily build the image using the Makefile:

--- a/vmware-esxi/README.md
+++ b/vmware-esxi/README.md
@@ -48,15 +48,6 @@ You can easily build the image using the Makefile:
 make ISO=/path/to/VMware-VMvisor-Installer-8.0b-21203435.x86_64.iso
 ```
 
-Alternatively you can manually run packer. Your current working directory must be in packer-maas/vmware-esxi, where this file is located. Once in packer-maas/vmware-esxi you can generate an image with:
-
-```shell
-sudo packer init .
-sudo PACKER_LOG=1 packer build -var 'vmware_esxi_iso_path=/path/to/VMware-VMvisor-Installer-8.0b-21203435.x86_64.iso' .
-```
-
-Note: vmware-esxi.pkr.hcl is configured to run Packer in headless mode. Only Packer output will be seen. If you wish to see the installation output connect to the VNC port given in the Packer output or remove the line containing "headless" in vmware-esxi.pkr.hcl.
-
 Installation is non-interactive.
 
 ### Makefile Parameters

--- a/vmware-esxi/vmware-esxi.pkr.hcl
+++ b/vmware-esxi/vmware-esxi.pkr.hcl
@@ -21,7 +21,7 @@ variable "timeout" {
 
 source "qemu" "esxi" {
   accelerator      = "kvm"
-  boot_command     = ["<enter><wait>", "<leftShift>O", " ks=usb://KS.CFG", " cpuUniformityHardCheckPanic=FALSE", " systemMediaSize=min", " com1_Port=0x3f8 tty2Port=com1", "<enter>"]
+  boot_command     = ["<enter><wait>", "<leftShift>O", " ks=usb://ks.cfg", " cpuUniformityHardCheckPanic=FALSE", " systemMediaSize=min", " com1_Port=0x3f8 tty2Port=com1", "<enter>"]
   boot_wait        = "3s"
   communicator     = "none"
   disk_size        = "32G"

--- a/vmware-esxi/vmware-esxi.pkr.hcl
+++ b/vmware-esxi/vmware-esxi.pkr.hcl
@@ -21,7 +21,7 @@ variable "timeout" {
 
 source "qemu" "esxi" {
   accelerator      = "kvm"
-  boot_command     = ["<enter><wait>", "<leftShift>O", " ks=usb://ks.cfg", " cpuUniformityHardCheckPanic=FALSE", " systemMediaSize=min", " com1_Port=0x3f8 tty2Port=com1", "<enter>"]
+  boot_command     = ["<enter><wait>", "<leftShift>O", " ks=usb:./KS.CFG", " cpuUniformityHardCheckPanic=FALSE", " systemMediaSize=min", " com1_Port=0x3f8 tty2Port=com1", "<enter>"]
   boot_wait        = "3s"
   communicator     = "none"
   disk_size        = "32G"

--- a/vmware-esxi/vmware-esxi.pkr.hcl
+++ b/vmware-esxi/vmware-esxi.pkr.hcl
@@ -21,7 +21,7 @@ variable "timeout" {
 
 source "qemu" "esxi" {
   accelerator      = "kvm"
-  boot_command     = ["<enter><wait>", "<leftShift>O", " ks=usb:./KS.CFG", " cpuUniformityHardCheckPanic=FALSE", " systemMediaSize=min", " com1_Port=0x3f8 tty2Port=com1", "<enter>"]
+  boot_command     = ["<enter><wait>", "<leftShift>O", " ks=usb://KS.CFG", " cpuUniformityHardCheckPanic=FALSE", " systemMediaSize=min", " com1_Port=0x3f8 tty2Port=com1", "<enter>"]
   boot_wait        = "3s"
   communicator     = "none"
   disk_size        = "32G"


### PR DESCRIPTION
VMWare ESXi template uses the `mformat` command in its Makefile. `mformat` is part of the `mtools` package.

This PR:
- add `mtools` as a dependency in the README.md
- add `mtools` check in the `Makefile`
- discourage user from using the `packer` command to create the images (use `make ISO=XXX` command instead)

