### PR TITLE
Added Fedora Server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Read more about how [custom images](https://maas.io/docs/how-to-customise-images
 | [Debian 11](debian/README.md)         | Beta               | x86_64 / aarch64  | >= 3.2           |
 | [Debian 12](debian/README.md)         | Beta               | x86_64 / aarch64  | >= 3.2           |
 | [Debian 13](debian/README.md)         | Beta               | x86_64 / aarch64  | >= 3.2           |
+| [Fedora Server 41](fedora-server/README.md)         | Beta               | x86_64 / aarch64  | >= 3.2           |
+| [Fedora Server 42](fedora-server/README.md)         | Beta               | x86_64 / aarch64  | >= 3.2           |
 | [OL8](ol8/README.md)               | Alpha              | x86_64            | >= 3.5           |
 | [OL9](ol9/README.md)               | Alpha              | x86_64            | >= 3.5           |
 | [RHEL 7](rhel7/README.md)            | EOL                | x86_64            | >= 2.3           |

--- a/fedora-server/Makefile
+++ b/fedora-server/Makefile
@@ -1,0 +1,66 @@
+#!/usr/bin/make -f
+
+include ../scripts/check.mk
+
+PACKER ?= packer
+PACKER_LOG ?= 0
+ISO ?= Fedora-Server-dvd-x86_64-42-1.1.iso
+TIMEOUT ?= 1h
+ARCH ?= x86_64
+VERSION ?= 42
+
+# Detect if running on ARM host
+ifeq ($(shell uname -m),aarch64)
+    HOST_IS_ARM = true
+else
+    HOST_IS_ARM = false
+endif
+
+ifeq ($(wildcard /usr/share/OVMF/OVMF_CODE.fd),)
+	OVMF_SFX ?= _4M
+else
+	OVMF_SFX ?=
+endif
+
+export PACKER_LOG
+
+# Fallback
+ifeq ($(strip $(ARCH)),amd64)
+	ARCH = x86_64
+endif
+
+.PHONY: all clean
+
+all: fedora-server.tar.gz
+
+$(eval $(call check_packages_deps))
+
+lint:
+	packer validate .
+	packer fmt -check -diff .
+
+format:
+	packer fmt .
+
+OVMF_VARS.fd: /usr/share/OVMF/OVMF_VARS${OVMF_SFX}.fd
+	cp -v $< ${ARCH}_VARS.fd
+
+SIZE_VARS.fd:
+ifeq ($(strip $(ARCH)),aarch64)
+	truncate -s 64m ${ARCH}_VARS.fd
+else
+	truncate -s 2m ${ARCH}_VARS.fd
+endif
+
+fedora-server.tar.gz: check-deps clean OVMF_VARS.fd SIZE_VARS.fd
+	${PACKER} init fedora-server.pkr.hcl && ${PACKER} build \
+							-var architecture=${ARCH} \
+							-var host_is_arm=${HOST_IS_ARM} \
+							-var ovmf_suffix=${OVMF_SFX} \
+							-var fedora_iso_path=${ISO} \
+							-var timeout=${TIMEOUT} \
+							-var version=${VERSION} \
+							fedora-server.pkr.hcl
+
+clean:
+	${RM} -rf *.fd output-fedora-server fedora-server.tar.gz

--- a/fedora-server/README.md
+++ b/fedora-server/README.md
@@ -1,0 +1,78 @@
+# Fedora Server Packer Template for MAAS
+
+## Introduction
+
+The Packer template in this directory creates a Fedora Server AMD64/ARM64 image for use with MAAS.
+
+## Prerequisites (to create the image)
+
+* A machine running Ubuntu 22.04+ with the ability to run KVM virtual machines.
+* qemu-utils, libnbd-bin, nbdkit and fuse2fs
+* [Packer](https://www.packer.io/intro/getting-started/install.html), v1.8.0 or newer
+* The [Fedora Server DVD ISO](https://fedoraproject.org/server/download)
+
+## Requirements (to deploy the image)
+
+* [MAAS](https://maas.io) 3.3+
+* [Curtin](https://launchpad.net/curtin) 22.1+
+
+## Customizing the Image
+
+The deployment image may be customized by modifying http/fedora-server.ks.pkrtpl.hcl. See the [Fedora kickstart documentation](https://docs.fedoraproject.org/en-US/fedora/f36/install-guide/advanced/Kickstart_Installations/) for more information.
+
+## Building an image
+
+You can easily build the image using the Makefile:
+
+```shell
+make ISO=/PATH/TO/Fedora-Server-dvd-x86_64-42-1.1.iso
+```
+
+Note: fedora-server.pkr.hcl is configured to run Packer in headless mode. Only Packer
+output will be seen. If you wish to see the installation output connect to the
+VNC port given in the Packer output or change the value of headless to false in
+fedora-server.pkr.hcl.
+
+Installation is non-interactive.
+
+### Makefile Parameters
+
+#### ARCH
+
+Defaults to x86_64 to build AMD64 compatible images. In order to build ARM64 images, use ARCH=aarch64
+
+#### ISO
+
+The path to the installation ISO image for Fedora Server.
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
+#### VERSION
+
+Fedora Server version. Default is currently set to 42. 
+
+## Uploading an image to MAAS
+
+```shell
+maas $PROFILE boot-resources create \
+    name='custom/fedora-server' title='Fedora Server Custom' \
+    architecture='amd64/generic' filetype='tgz' \
+    base_image='rhel/9' content@=fedora-server.tar.gz
+```
+
+For ARM64, use:
+
+```shell
+maas $PROFILE boot-resources create \
+    name='custom/fedora-server' title='Fedora Server Custom' \
+    architecture='arm64/generic' filetype='tgz' \
+    base_image='rhel/9' content@=fedora-server.tar.gz
+```
+
+This file needs to be saved on Region Controllers under /var/snap/maas/current/preseeds/curtin_userdata_rhel_arm64_generic_fedora-server or /etc/maas/preseeds/curtin_userdata_rhel_arm64_generic_fedora-server. The last portion of this file must match the image name uploaded in MAAS.
+
+## Default Username
+
+The default username is ```fedora```

--- a/fedora-server/curtin/curtin-hooks
+++ b/fedora-server/curtin/curtin-hooks
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright (C) 202 5 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import os
+import shutil
+import platform
+
+from curtin import distro, util
+from curtin.config import load_command_config
+from curtin.log import LOG
+from curtin.paths import target_path
+from curtin.util import load_command_environment, ChrootableTarget
+from curtin.commands import curthooks
+
+def run_hook_in_target(target, hook):
+    """Look for "hook" in "target" and run in a chroot"""
+    target_hook = target_path(target, '/curtin/' + hook)
+    if os.path.isfile(target_hook):
+        LOG.debug("running %s" % target_hook)
+        with ChrootableTarget(target=target) as in_chroot:
+            in_chroot.subp(['/curtin/' + hook])
+        return True
+    return False
+
+def curthook(cfg, target, state):
+    """Configure network and bootloader"""
+    LOG.info('Running curtin builtin curthooks')
+    state_etcd = os.path.split(state['fstab'])[0]
+    machine = platform.machine()
+
+    distro_info = distro.get_distroinfo(target=target)
+    if not distro_info:
+        raise RuntimeError('Failed to determine target distro')
+    osfamily = distro_info.family
+    LOG.info('Configuring target system for distro: %s osfamily: %s',
+             distro_info.variant, osfamily)
+    
+    sources = cfg.get('sources', {})
+    dd_image = len(util.get_dd_images(sources)) > 0
+
+    curthooks.disable_overlayroot(cfg, target)
+    curthooks.disable_update_initramfs(cfg, target, machine)
+    
+    if not dd_image:
+        curthooks.configure_iscsi(cfg, state_etcd, target, osfamily=osfamily)
+        curthooks.configure_mdadm(cfg, state_etcd, target, osfamily=osfamily)
+        curthooks.copy_fstab(state.get('fstab'), target)
+        curthooks.add_swap(cfg, target, state.get('fstab'))
+
+    curthooks.apply_networking(target, state)
+    curthooks.handle_pollinate_user_agent(cfg, target)
+    
+    # set cloud-init maas datasource
+    if cfg.get('cloudconfig'):
+        curthooks.handle_cloudconfig(
+                      cfg['cloudconfig'],
+                      base_dir=target_path(target,
+                                                 'etc/cloud/cloud.cfg.d'))
+
+    run_hook_in_target(target, 'setup-bootloader')
+
+def cleanup():
+    """Remove curtin-hooks so its as if we were never here."""
+    curtin_dir = os.path.dirname(__file__)
+    shutil.rmtree(curtin_dir)
+
+
+def main():
+    state = load_command_environment()
+    config = load_command_config(None, state)
+    target = state['target']
+
+    curthook(config, target, state)
+    cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/fedora-server/curtin/setup-bootloader
+++ b/fedora-server/curtin/setup-bootloader
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Update All initramfs files
+for kernel in $(ls /lib/modules/); do
+  dracut --force /boot/initramfs-${kernel}.img ${kernel}
+done
+
+# Reinstall shim
+dnf reinstall -y shim-*
+
+# Generate the GRUB config file
+mkdir -p /boot/efi/EFI/fedora/
+grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
+
+# Install GRUB and update the configuration
+if [ -d /sys/firmware/efi/efivars/ ]; then
+        # Fix boot delays due to PXE loop
+        cp /boot/efi/EFI/fedora/grub* /boot/efi/EFI/boot/
+        cp /boot/efi/EFI/fedora/*.efi /boot/efi/EFI/boot/
+else
+        grub_dev="/dev/$(lsblk -r | grep 'part /$' | awk '{print $1}' | sed s/[0-9]//g)"
+
+        grub2-install \
+            --target=i386-pc \
+            --recheck ${grub_dev}
+fi
+exit 0

--- a/fedora-server/fedora-server.pkr.hcl
+++ b/fedora-server/fedora-server.pkr.hcl
@@ -1,0 +1,129 @@
+packer {
+  required_version = ">= 1.7.0"
+  required_plugins {
+    qemu = {
+      version = "~> 1.0"
+      source  = "github.com/hashicorp/qemu"
+    }
+  }
+}
+
+variable "filename" {
+  type        = string
+  default     = "fedora-server.tar.gz"
+  description = "The filename of the tarball to produce"
+}
+
+variable "fedora_iso_path" {
+  type    = string
+  default = "${env("FEDORA_SERVER_ISO_PATH")}"
+}
+
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
+variable "architecture" {
+  type        = string
+  default     = "amd64"
+  description = "The architecture to build the image for (amd64 or arm64)"
+}
+
+variable "host_is_arm" {
+  type        = bool
+  default     = false
+  description = "The host architecture is aarch64"
+}
+
+variable "ovmf_suffix" {
+  type        = string
+  default     = ""
+  description = "Suffix for OVMF CODE and VARS files. Newer systems such as Noble use _4M."
+}
+
+variable "version" {
+  type    = string
+  default = "42"
+}
+
+locals {
+  qemu_arch = {
+    "x86_64"  = "x86_64"
+    "aarch64" = "aarch64"
+  }
+  uefi_imp = {
+    "x86_64"  = "OVMF"
+    "aarch64" = "AAVMF"
+  }
+  uefi_sfx = {
+    "x86_64"  = "${var.ovmf_suffix}"
+    "aarch64" = ""
+  }
+  qemu_machine = {
+    "x86_64"  = "accel=kvm"
+    "aarch64" = var.host_is_arm ? "virt,accel=kvm" : "virt"
+  }
+  qemu_cpu = {
+    "x86_64"  = "host"
+    "aarch64" = var.host_is_arm ? "host" : "max"
+  }
+}
+
+
+source "qemu" "fedora-server" {
+  boot_command     = ["<up><wait>", "e", "<down><down><down><left>", " console=ttyS0 inst.cmdline inst.text inst.ks=http://{{.HTTPIP}}:{{.HTTPPort}}/fedora-server.ks <f10>"]
+  boot_wait        = "5s"
+  communicator     = "none"
+  disk_size        = "8G"
+  headless         = true
+  iso_checksum     = "none"
+  iso_url          = var.fedora_iso_path
+  memory           = 2048
+  cpus             = 4
+  qemu_binary      = "qemu-system-${lookup(local.qemu_arch, var.architecture, "")}"
+  qemuargs = [
+    ["-serial", "stdio"],
+    ["-boot", "strict=off"],
+    ["-device", "qemu-xhci"],
+    ["-device", "usb-kbd"],
+    ["-device", "virtio-net-pci,netdev=net0"],
+    ["-netdev", "user,id=net0"],
+    ["-device", "virtio-blk-pci,drive=drive0,bootindex=0"],
+    ["-device", "virtio-blk-pci,drive=cdrom0,bootindex=1"],
+    ["-machine", "${lookup(local.qemu_machine, var.architecture, "")}"],
+    ["-cpu", "${lookup(local.qemu_cpu, var.architecture, "")}"],
+    ["-device", "virtio-gpu-pci"],
+    ["-global", "driver=cfi.pflash01,property=secure,value=off"],
+    ["-drive", "if=pflash,format=raw,unit=0,id=ovmf_code,readonly=on,file=/usr/share/${lookup(local.uefi_imp, var.architecture, "")}/${lookup(local.uefi_imp, var.architecture, "")}_CODE${lookup(local.uefi_sfx, var.architecture, "")}.fd"],
+    ["-drive", "if=pflash,format=raw,unit=1,id=ovmf_vars,file=${var.architecture}_VARS.fd"],
+    ["-drive", "file=output-fedora-server/packer-fedora-server,if=none,id=drive0,cache=writeback,discard=ignore,format=qcow2"],
+    ["-drive", "file=${var.fedora_iso_path},if=none,id=cdrom0,media=cdrom"]
+  ]
+  shutdown_timeout = var.timeout
+  http_content = {
+    "/fedora-server.ks" = templatefile("${path.root}/http/fedora-server.ks.pkrtpl.hcl",
+      {
+        KS_VERSION = var.version,
+        KS_ARCH    = "${lookup(local.qemu_arch, var.architecture, "")}",
+      }
+    )
+  }
+}
+
+build {
+  sources = ["source.qemu.fedora-server"]
+
+  post-processor "shell-local" {
+    inline = [
+      "SOURCE=${source.name}",
+      "OUTPUT=${var.filename}",
+      "ROOT_PARTITION=2",
+      "source ../scripts/fuse-nbd",
+      "source ../scripts/fuse-tar-root",
+      "rm -rf output-${source.name}",
+    ]
+    inline_shebang = "/bin/bash -e"
+  }
+}

--- a/fedora-server/http/fedora-server.ks.pkrtpl.hcl
+++ b/fedora-server/http/fedora-server.ks.pkrtpl.hcl
@@ -1,0 +1,74 @@
+poweroff
+eula --agreed
+firewall --enabled --service=ssh
+firstboot --disable
+lang en_US.UTF-8
+keyboard us
+network --device eth0 --bootproto=dhcp
+firewall --enabled --service=ssh
+selinux --enforcing
+timezone UTC --utc
+rootpw --plaintext password
+
+ignoredisk --only-use=vda
+bootloader --disabled
+zerombr
+clearpart --all --initlabel
+part swap --size=2048
+part / --fstype=ext4 --grow --size=1
+
+
+%post --erroronfail
+# workaround anaconda requirements and clear root password
+passwd -d root
+passwd -l root
+
+# Clean up install config not applicable to deployed environments.
+for f in resolv.conf fstab; do
+    rm -f /etc/$f
+    touch /etc/$f
+    chown root:root /etc/$f
+    chmod 644 /etc/$f
+done
+
+rm -f /etc/sysconfig/network-scripts/ifcfg-[^lo]*
+
+# Kickstart copies install boot options. Serial is turned on for logging with
+# Packer which disables console output. Disable it so console output is shown
+# during deployments
+sed -i 's/^GRUB_TERMINAL=.*/GRUB_TERMINAL_OUTPUT="console"/g' /etc/default/grub
+sed -i '/GRUB_SERIAL_COMMAND="serial"/d' /etc/default/grub
+sed -ri 's/(GRUB_CMDLINE_LINUX=".*)\s+console=ttyS0(.*")/\1\2/' /etc/default/grub
+sed -i 's/GRUB_ENABLE_BLSCFG=.*/GRUB_ENABLE_BLSCFG=false/g' /etc/default/grub
+
+dnf clean all
+%end
+
+repo --name=fedora-server --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-${KS_VERSION}&arch=${KS_ARCH}
+
+%packages --ignoremissing
+@^server-product-environment
+bash-completion
+cloud-init
+# cloud-init only requires python3-oauthlib with MAAS. As such upstream
+# removed this dependency.
+python3-oauthlib
+rsync
+tar
+# grub2-efi-x64 ships grub signed for UEFI secure boot. If grub2-efi-x64-modules
+# is installed grub will be generated on deployment and unsigned which breaks
+# UEFI secure boot.
+grub2-pc
+grub2-efi-*
+shim-*
+grub2-efi-*-modules
+efibootmgr
+dosfstools
+lvm2
+mdadm
+device-mapper-multipath
+iscsi-initiator-utils
+-plymouth
+# Remove Intel wireless firmware
+-i*-firmware
+%end


### PR DESCRIPTION
Added Fedora Server support

- This template adds Fedora Server dual-arch support to packer-maas.
- Currently tested with Fedora Server 41 and 42.