### PR TITLE
Windows: Use qemu-plugin to < 1.1.2

### DIFF
--- a/windows/windows.pkr.hcl
+++ b/windows/windows.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_version = ">= 1.7.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }


### PR DESCRIPTION
Hardcode required qemu-plugin to < 1.1.2 due to upstream [Bug #13410](https://github.com/hashicorp/packer/issues/13410)