### PR TITLE
install-custom-packages (Apt): ensure index currency

### DIFF
--- a/debian/scripts/install-custom-packages
+++ b/debian/scripts/install-custom-packages
@@ -39,6 +39,7 @@ dpkg -l 'linux-image-*' 'linux-headers-*' | awk '/^ii/{print $2}' | xargs apt-ge
 echo "install new kernel"
 tar xzvf "${PKG_TGZ}" -C "${WORKDIR}"
 DEBS=$(find "${WORKDIR}" -name '*.deb')
+apt-get update
 apt-get install -y --no-install-recommends ${DEBS}
 apt-get install --fix-broken
 

--- a/ubuntu/scripts/install-custom-packages
+++ b/ubuntu/scripts/install-custom-packages
@@ -39,6 +39,7 @@ dpkg -l 'linux-image-*' 'linux-headers-*' | awk '/^ii/{print $2}' | xargs apt-ge
 echo "install new kernel"
 tar xzvf "${PKG_TGZ}" -C "${WORKDIR}"
 DEBS=$(find "${WORKDIR}" -name '*.deb')
+apt-get update
 apt-get install -y --no-install-recommends ${DEBS}
 apt-get install --fix-broken
 


### PR DESCRIPTION
Custom packages may fail when the Apt caches go stale between time of image creation and image deployment. For instance:
```shell
 ++ find /tmp/tmp.89tFEo8XBd -name '*.deb'
 + DEBS='/tmp/tmp.89tFEo8XBd/...
 + apt-get install -y --no-install-recommends ...
Reading package lists...
        Building dependency tree...
        Reading state information...
        The following additional packages will be installed:
[...]
        Err:6 http://security.ubuntu.com/ubuntu jammy-updates/main amd64 libc6-i386 amd64 2.35-0ubuntu3.9
          404  Not Found [IP: 91.189.91.82 80]
        Err:7 http://security.ubuntu.com/ubuntu jammy-updates/main amd64 libc6-dbg amd64 2.35-0ubuntu3.9
          404  Not Found [IP: 91.189.91.82 80]
        Get:15 http://us.archive.ubuntu.com/ubuntu jammy-updates/main amd64 lib32gcc-s1 amd64 12.3.0-1ubuntu1~22.04 [63.9 kB]
        Get:16 http://us.archive.ubuntu.com/ubuntu jammy/main amd64 python3-psutil amd64 5.9.0-1build1 [158 kB]
```
This proposal should ensure currency.