### PR TITLE
install-custom-packages/chroot: derive Apt proxy from installer

### DIFF
--- a/debian/scripts/install-custom-packages
+++ b/debian/scripts/install-custom-packages
@@ -33,6 +33,11 @@ cleanup() {
 }
 trap cleanup EXIT
 
+echo 'Apt proxy (Optional, MaaS/Subnet config)'
+CI_COMBINED_JSON=/run/cloud-init/combined-cloud-config.json
+[ -f "$CI_COMBINED_JSON" ] && APT_PROXY=$(jq -r '.apt.proxy // ""' "$CI_COMBINED_JSON")  # rewrite literal 'null' to empty str for next test [when not in JSON]
+[ -n "$APT_PROXY" ] && printf 'Acquire::http::Proxy "%s";\nAcquire::https::Proxy "%s";' "$APT_PROXY"{,} | tee /etc/apt/apt.conf.d/90cloud-init-aptproxy
+
 echo "remove existing kernels"
 dpkg -l 'linux-image-*' 'linux-headers-*' | awk '/^ii/{print $2}' | xargs apt-get -y purge
 

--- a/ubuntu/scripts/install-custom-packages
+++ b/ubuntu/scripts/install-custom-packages
@@ -33,6 +33,11 @@ cleanup() {
 }
 trap cleanup EXIT
 
+echo 'Apt proxy (Optional, MaaS/Subnet config)'
+CI_COMBINED_JSON=/run/cloud-init/combined-cloud-config.json
+[ -f "$CI_COMBINED_JSON" ] && APT_PROXY=$(jq -r '.apt.proxy // ""' "$CI_COMBINED_JSON")  # rewrite literal 'null' to empty str for next test [when not in JSON]
+[ -n "$APT_PROXY" ] && printf 'Acquire::http::Proxy "%s";\nAcquire::https::Proxy "%s";' "$APT_PROXY"{,} | tee /etc/apt/apt.conf.d/90cloud-init-aptproxy
+
 echo "remove existing kernels"
 dpkg -l 'linux-image-*' 'linux-headers-*' | awk '/^ii/{print $2}' | xargs apt-get -y purge
 


### PR DESCRIPTION
Custom packages are processed inside `chroot` after unpacking the image. If the network requires a proxy _(either MaaS-hosted or external)_, the transaction will fail _[without these changes or transparent proxying]_.

The `chroot` in the new install _does not_ benefit from the `cloud-init` configuration of _Apt_ in the network-booted _(live)_ environment. These changes take advantage of the `/run` mount _(and `jq`)_ to carry this information into the newly-created installation.