### PR TITLE
refactor: pin qemu plugin version

### DIFF
--- a/alma8/alma8.pkr.hcl
+++ b/alma8/alma8.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/alma9/alma9.pkr.hcl
+++ b/alma9/alma9.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/centos6/centos6.pkr.hcl
+++ b/centos6/centos6.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/centos7/centos7.pkr.hcl
+++ b/centos7/centos7.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/centos8-stream/centos8-stream.pkr.hcl
+++ b/centos8-stream/centos8-stream.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/centos8/centos8.pkr.hcl
+++ b/centos8/centos8.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/centos9-stream/centos9-stream.pkr.hcl
+++ b/centos9-stream/centos9-stream.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/debian/variables.pkr.hcl
+++ b/debian/variables.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/fedora-server/fedora-server.pkr.hcl
+++ b/fedora-server/fedora-server.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/ol8/ol8.pkr.hcl
+++ b/ol8/ol8.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/ol9/ol9.pkr.hcl
+++ b/ol9/ol9.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/rhel10/rhel10.pkr.hcl
+++ b/rhel10/rhel10.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/rhel7/rhel7.pkr.hcl
+++ b/rhel7/rhel7.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/rhel8/rhel8.pkr.hcl
+++ b/rhel8/rhel8.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/rhel9/rhel9.pkr.hcl
+++ b/rhel9/rhel9.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/rocky8/rocky8.pkr.hcl
+++ b/rocky8/rocky8.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/rocky9/rocky9.pkr.hcl
+++ b/rocky9/rocky9.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/sles12/sles.pkr.hcl
+++ b/sles12/sles.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/sles15/sles.pkr.hcl
+++ b/sles15/sles.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/sles16/sles.pkr.hcl
+++ b/sles16/sles.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/ubuntu/variables.pkr.hcl
+++ b/ubuntu/variables.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/vmware-esxi/vmware-esxi.pkr.hcl
+++ b/vmware-esxi/vmware-esxi.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_version = ">= 1.12.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/windows/windows.pkr.hcl
+++ b/windows/windows.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
       version = ">= 1.1.0, < 1.1.2"

--- a/xenserver8/xenserver8.pkr.hcl
+++ b/xenserver8/xenserver8.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = "~> 1.0"
+      version = ">= 1.1.0, < 1.1.2"
       source  = "github.com/hashicorp/qemu"
     }
   }


### PR DESCRIPTION
Starting with version 1.1.2, the qemu plugin no longer waits for the machine to shutdown if there's no `communicator` set in the template. Most packer-maas templates rely on this behavior.

Let's pin the plugin to the last working version until we find out whether this is a regression in the plug-in or an undocumented behavior that we were inadvertently exploiting.

Fixes #323