### PR TITLE
Add ubuntu cloudimg customization example for BlueField

### DIFF
--- a/ubuntu/Makefile
+++ b/ubuntu/Makefile
@@ -75,7 +75,7 @@ endif
 
 custom-cloudimg.tar.gz: check-deps clean OVMF_CODE.fd OVMF_VARS.fd SIZE_CODE.fd SIZE_VARS.fd
 	${PACKER} init . && ${PACKER} build \
-		-only='cloudimg.*' \
+		-only='cloudimg.*' $(if ${CUSTOMIZE},-var customize_script=${CUSTOMIZE}) \
 		-var ubuntu_series=${SERIES} \
 		-var architecture=${ARCH} \
 		-var host_is_arm=${HOST_IS_ARM} \

--- a/ubuntu/README.md
+++ b/ubuntu/README.md
@@ -93,6 +93,16 @@ packer build -var architecture=arm64 -var customize_script=my-changes.sh \
     -only='cloudimg.*' .
 ```
 
+### Customization example: BlueField DPU
+
+An example of how to use the _customize_script_ to build an image for
+BlueField DPUs is provided. The kernel and packages for the NVIDIA DOCA version
+installed by the customization script require the use of _jammy_ as Ubuntu series.
+
+```shell
+make custom-cloudimg.tar.gz SERIES=jammy ARCH=arm64 CUSTOMIZE=scripts/examples/bluefield-doca-2-9-lts.sh
+```
+
 ## ubuntu-flat.pkr.hcl and ubuntu-lvm.pkr.hcl
 
 These templates use an Ubuntu server image to install the image to the VM. It
@@ -165,6 +175,10 @@ The file name for the checksums file. The default value is set to SHA256SUMS.
 #### TIMEOUT
 
 The timeout to apply when building the image. The default value is set to 1h.
+
+#### CUSTOMIZE
+
+When specified, use the provided file to customize the content of ubuntu-cloudimg.
 
 ### Default Username
 

--- a/ubuntu/scripts/examples/bluefield-doca-2-9-lts.sh
+++ b/ubuntu/scripts/examples/bluefield-doca-2-9-lts.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+export DEBIAN_FRONTEND=noninteractive
+
+GPG_KEY="GPG-KEY-Mellanox.pub"
+DPU_ARCH="aarch64"
+DOCA_VERSION="latest-2.9-LTS"
+TMP_KEYRING="/tmp/mellanox-keyring.gpg"
+MELLANOX_GPG="/etc/apt/keyrings/mellanox.gpg"
+BF_KERNEL_VERSION="5.15.0.1060.62"
+BF_KERNEL_VERSION_DASH="5.15.0-1060.62"
+
+mkdir -p /etc/apt/keyrings
+wget https://linux.mellanox.com/public/repo/doca/$DOCA_VERSION/ubuntu22.04/$DPU_ARCH/$GPG_KEY
+gpg --no-default-keyring --keyring $TMP_KEYRING --import ./$GPG_KEY
+gpg --no-default-keyring --keyring $TMP_KEYRING --export --output $MELLANOX_GPG
+rm $TMP_KEYRING
+echo "deb [signed-by=$MELLANOX_GPG] https://linux.mellanox.com/public/repo/doca/$DOCA_VERSION/ubuntu22.04/$DPU_ARCH ./" | tee /etc/apt/sources.list.d/doca.list
+
+apt-get update
+apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -f \
+    linux-bluefield=$BF_KERNEL_VERSION \
+    linux-bluefield-cloud-tools-common=$BF_KERNEL_VERSION_DASH \
+    linux-bluefield-headers-5.15.0-1060=$BF_KERNEL_VERSION_DASH \
+    linux-bluefield-tools-5.15.0-1060=$BF_KERNEL_VERSION_DASH \
+    linux-buildinfo-5.15.0-1060-bluefield=$BF_KERNEL_VERSION_DASH \
+    linux-headers-5.15.0-1060-bluefield=$BF_KERNEL_VERSION_DASH \
+    linux-headers-bluefield=$BF_KERNEL_VERSION \
+    linux-image-5.15.0-1060-bluefield=$BF_KERNEL_VERSION_DASH \
+    linux-image-bluefield=$BF_KERNEL_VERSION \
+    linux-modules-5.15.0-1060-bluefield=$BF_KERNEL_VERSION_DASH \
+    linux-modules-extra-5.15.0-1060-bluefield=$BF_KERNEL_VERSION_DASH \
+    linux-tools-5.15.0-1060-bluefield=$BF_KERNEL_VERSION_DASH \
+    linux-tools-bluefield=$BF_KERNEL_VERSION \
+    linux-libc-dev:arm64 \
+    linux-tools-common \
+    mlnx-ofed-kernel-modules \
+    doca-runtime \
+    doca-devel \
+    mlnx-fw-updater-signed
+
+apt-mark hold linux-tools-bluefield linux-image-bluefield linux-bluefield \
+        linux-headers-bluefield linux-image-bluefield linux-libc-dev \
+        linux-tools-common mlnx-ofed-kernel-modules doca-runtime doca-devel
+
+sed -i -e "s/FORCE_MODE=.*/FORCE_MODE=yes/" /etc/infiniband/openib.conf
+
+# Remove conflicting and unused configurations from bf-release
+sed -i \
+    -e 's/^GRUB_CMDLINE_LINUX_DEFAULT=.*/GRUB_CMDLINE_LINUX_DEFAULT="text debug console=hvc0 console=ttyAMA0 earlycon=pl011,0x13010000 fixrtc net.ifnames=0 biosdevname=0 iommu.passthrough=1 earlyprintk=efi,keep"/' \
+    -e 's/^GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX=""/' \
+    /etc/default/grub
+rm /etc/cloud/cloud.cfg.d/91-dib-cloud-init-datasources.cfg
+rm /etc/netplan/60-mlnx.yaml
+
+sed -i -E "s/(_unsigned|_prod|_dev)/_packer_maas/;" /etc/mlnx-release
+
+systemctl enable NetworkManager.service || true
+systemctl enable NetworkManager-wait-online.service || true
+systemctl enable acpid.service || true
+systemctl enable mlx-openipmi.service || true
+systemctl enable mlx_ipmid.service || true
+systemctl enable set_emu_param.service || true
+systemctl enable mst || true
+systemctl disable openvswitch-ipsec || true
+systemctl disable srp_daemon.service || true
+systemctl disable ibacm.service || true
+systemctl disable opensmd.service || true
+systemctl disable unattended-upgrades.service || true
+systemctl disable apt-daily-upgrade.timer || true
+systemctl disable containerd.service || true
+systemctl disable ModemManager.service || true
+
+# OpenVSwitch related configuration
+echo vm.nr_hugepages = 1024 >> /etc/sysctl.conf
+ovs-vsctl --no-wait set Open_vSwitch . other_config:doca-init=true
+ovs-vsctl --no-wait set Open_vSwitch . other_config:hw-offload=true
+ovs-vsctl --no-wait set Open_vSwitch . other_config:default-datapath-type=netdev
+
+# Static configuration for tmfifo_net0 and OVS bridges (not configurable by MAAS)
+cat > /etc/netplan/60-tmfifo-ovsbr.yaml <<EOF
+network:
+    version: 2
+    ethernets:
+        tmfifo_net0:
+            addresses:
+            - 192.168.100.2/30
+            mtu: 1500
+        pf0hpf:
+            renderer: networkd
+            dhcp4: false
+            mtu: 9000
+        pf1hpf:
+            renderer: networkd
+            dhcp4: false
+            mtu: 9000
+    bridges:
+        ovsbr1:
+            mtu: 9000
+            interfaces:
+            - eth1
+            - pf0hpf
+            parameters:
+                forward-delay: "15"
+                stp: false
+            openvswitch: {}
+        ovsbr2:
+            mtu: 9000
+            interfaces:
+            - eth2
+            - pf1hpf
+            parameters:
+                forward-delay: "15"
+                stp: false
+            openvswitch: {}
+EOF
+
+mkdir -p /curtin
+echo -n "linux-bluefield=$BF_KERNEL_VERSION" > /curtin/CUSTOM_KERNEL


### PR DESCRIPTION
It is possible to use the ubuntu-cloudimg template to build images that can run on BlueField DPUs.
This commit adds a customization script that installs all NVIDIA software (bluefield kernel, modules, tools, and runtime software, based on the [bfb-build Dockerfile for DOCA 2.9 LTS](https://github.com/Mellanox/bfb-build/blob/lts-2.9.x/ubuntu/22.04/Dockerfile)) required to deploy a ready to use Ubuntu image on these devices with MAAS.
The Readme and Makefile have been updated to describe how this customization script can be used. It's important to note that BlueField images must be created with `ubuntu_series=jammy` (at least for DOCA 2.9 LTS) and `architecture=arm64`.
The customization  script includes the netplan configuration for the tmfifo_net0 interface and the definition of OVS briges for the host interfaces representors, because MAAS cannot control them as of today.