### PR TITLE
Update CentOS-8 packer

### DIFF
--- a/centos8/Makefile
+++ b/centos8/Makefile
@@ -4,7 +4,7 @@ include ../scripts/check.mk
 
 PACKER ?= packer
 PACKER_LOG ?= 0
-KS_MIRROR ?= http://mirrorlist.centos.org
+KS_MIRROR ?= https://vault.centos.org
 TIMEOUT ?= 1h
 export PACKER_LOG
 

--- a/centos8/README.md
+++ b/centos8/README.md
@@ -74,7 +74,7 @@ The timeout to apply when building the image. The default value is set to 1h.
 maas $PROFILE boot-resources create \
     name='centos/8-custom' title='CentOS 8 Custom' \
     architecture='amd64/generic' filetype='tgz' \
-    content@=centos8.tar.gz
+    base_image='centos/8' content@=centos8.tar.gz
 ```
 
 ## Default Username

--- a/centos8/centos8.pkr.hcl
+++ b/centos8/centos8.pkr.hcl
@@ -16,30 +16,30 @@ variable "filename" {
 
 variable "centos8_iso_url" {
   type    = string
-  default = "https://mirrors.edge.kernel.org/centos/8.4.2105/isos/x86_64/CentOS-8.4.2105-x86_64-boot.iso"
+  default = "https://vault.centos.org/8.5.2111/isos/x86_64/CentOS-8.5.2111-x86_64-boot.iso"
 }
 
 variable "centos8_sha256sum_url" {
   type    = string
-  default = "https://mirrors.edge.kernel.org/centos/8.4.2105/isos/x86_64/CHECKSUM"
+  default = "https://vault.centos.org/8.5.2111/isos/x86_64/CHECKSUM"
 }
 
 # use can use "--url" to specify the exact url for BaseOS repo
 variable "ks_os_repos" {
   type    = string
-  default = "--mirrorlist='http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=BaseOS'"
+  default = "--url='https://vault.centos.org/8.5.2111/BaseOS/x86_64/os/'"
 }
 
 # Use --baseurl to specify the exact url for AppStream repo
 variable "ks_appstream_repos" {
   type    = string
-  default = "--mirrorlist='http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=AppStream'"
+  default = "--baseurl='https://vault.centos.org/8.5.2111/AppStream/x86_64/os/'"
 }
 
 # Use --baseurl to specify the exact url for extras repo
 variable "ks_extras_repos" {
   type    = string
-  default = "--mirrorlist='http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=extras'"
+  default = "--baseurl='https://vault.centos.org/8.5.2111/extras/x86_64/os/'"
 }
 
 variable ks_proxy {


### PR DESCRIPTION
Update CentOS8 packer to point to vault url instead of mirrors url.
This fixes the packaging issues as the [mirrors](https://mirrors.edge.kernel.org/centos/8.4.2105/) for CentOS8 are deprected.