### PR TITLE
Windows: Use qemu-plugin to > 1.1.3

### DIFF
--- a/windows/windows.pkr.hcl
+++ b/windows/windows.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_version = ">= 1.11.0"
   required_plugins {
     qemu = {
-      version = ">= 1.1.0, < 1.1.2"
+      version = ">= 1.1.3"
       source  = "github.com/hashicorp/qemu"
     }
   }


### PR DESCRIPTION
Windows: Use qemu-plugin to > 1.1.3 due to:

    https://github.com/hashicorp/packer-plugin-qemu/issues/197
    https://github.com/hashicorp/packer-plugin-qemu/issues/198