### PR TITLE
rocky9 image fails deployment

### DIFF
--- a/rocky9/http/rocky9.ks.pkrtpl.hcl
+++ b/rocky9/http/rocky9.ks.pkrtpl.hcl
@@ -66,7 +66,7 @@ sed -i '/GRUB_SERIAL_COMMAND="serial"/d' /etc/default/grub
 sed -ri 's/(GRUB_CMDLINE_LINUX=".*)\s+console=ttyS0(.*")/\1\2/' /etc/default/grub
 sed -i 's/GRUB_ENABLE_BLSCFG=.*/GRUB_ENABLE_BLSCFG=false/g' /etc/default/grub
 
-yum clean all
+dnf clean all
 
 # Passwordless sudo for the user 'rocky'
 echo "rocky ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/rocky
@@ -87,8 +87,8 @@ chmod 440 /etc/sudoers.d/rocky
 
 %end
 
-%packages
-@Core
+%packages  --ignoremissing
+@core
 bash-completion
 cloud-init
 cloud-utils-growpart
@@ -96,9 +96,10 @@ rsync
 tar
 patch
 yum-utils
-grub2-efi-x64
-shim-x64
-grub2-efi-x64-modules
+grub2-pc
+grub2-efi-*
+shim-*
+grub2-efi-*-modules
 efibootmgr
 dosfstools
 lvm2


### PR DESCRIPTION
Addition of package `grub2-pc` resolves the deployment issue for Rocky9.

From the deployed VM:
```
$ ssh -oStrictHostKeyChecking=no cloud-user@192.168.122.227
Warning: Permanently added '192.168.122.227' (ED25519) to the list of known hosts.

[cloud-user@brave-sponge ~]$ cat /etc/system-release
Rocky Linux release 9.6 (Blue Onyx)

[cloud-user@brave-sponge ~]$ cat /etc/os-release 
NAME="Rocky Linux"
VERSION="9.6 (Blue Onyx)"
ID="rocky"
ID_LIKE="rhel centos fedora"
VERSION_ID="9.6"
PLATFORM_ID="platform:el9"
PRETTY_NAME="Rocky Linux 9.6 (Blue Onyx)"
ANSI_COLOR="0;32"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:rocky:rocky:9::baseos"
HOME_URL="https://rockylinux.org/"
VENDOR_NAME="RESF"
VENDOR_URL="https://resf.org/"
BUG_REPORT_URL="https://bugs.rockylinux.org/"
SUPPORT_END="2032-05-31"
ROCKY_SUPPORT_PRODUCT="Rocky-Linux-9"
ROCKY_SUPPORT_PRODUCT_VERSION="9.6"
REDHAT_SUPPORT_PRODUCT="Rocky Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="9.6"
```

This could possibly fix #100