### PR TITLE
AlmaLinux Overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Read more about how [custom images](https://canonical.com/maas/docs/how-to-build
 | **OS**            | **Maturity Level** | **Architecture**  | **MAAS Version** |
 |-------------------|:------------------:|:-----------------:|:-----------------|
 | [Azure Local (HCI)](windows/README.md) | Beta               | x86_64            | >= 3.3           |
-| [AlmaLinux 8](alma8/README.md)       | Beta               | x86_64            | >= 3.5           |
-| [AlmaLinux 9](alma9/README.md)       | Beta               | x86_64            | >= 3.5           |
+| [AlmaLinux 8](alma8/README.md)       | Beta               | x86_64 / aarch64  | >= 3.3           |
+| [AlmaLinux 9](alma9/README.md)       | Beta               | x86_64 / aarch64  | >= 3.3           |
+| [AlmaLinux 10](alma10/README.md)     | Beta               | x86_64 / aarch64  | >= 3.3           |
 | [AzureLinux 2.0](azurelinux/README.md)    | Beta               | x86_64            | >= 3.3           |
 | [CentOS 6](centos6/README.md)          | EOL                | x86_64            | >= 1.6           |
 | [CentOS 7](centos7/README.md)          | EOL                | x86_64            | >= 2.3           |

--- a/alma10/README.md
+++ b/alma10/README.md
@@ -17,8 +17,7 @@ The Packer template in this directory creates a Alma 10 AMD64/ARM64 image for us
 
 ## Requirements to deploy the image
 
-* [MAAS](https://maas.io) 3.5 or later, as that version introduces support for Alma
-* [Curtin](https://launchpad.net/curtin) 23.1 or later. If you have a MAAS with an earlier Curtin version, you can [patch](https://code.launchpad.net/~alexsander-souza/curtin/+git/curtin/+merge/462367) distro.py to deploy Alma.
+* [MAAS](https://maas.io) 3.3 or later
 
 ## Customizing the image
 

--- a/alma10/curtin/curtin-hooks
+++ b/alma10/curtin/curtin-hooks
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import os
+import shutil
+import platform
+import sys
+
+from curtin import distro, util
+from curtin.config import load_command_config
+from curtin.log import LOG
+from curtin.paths import target_path
+from curtin.util import load_command_environment, ChrootableTarget
+from curtin.commands import curthooks
+
+def run_hook_in_target(target, hook):
+    """Look for "hook" in "target" and run in a chroot"""
+    target_hook = target_path(target, '/curtin/' + hook)
+    if os.path.isfile(target_hook):
+        LOG.debug("running %s" % target_hook)
+        with ChrootableTarget(target=target) as in_chroot:
+            in_chroot.subp(['/curtin/' + hook])
+        return True
+    return False
+
+def curthook(cfg, target, state):
+    """Configure network and bootloader"""
+    if "almalinux" in distro.DISTRO_NAMES:
+      LOG.info("Native Curtin support is available, running builtin hooks")
+      curthooks.builtin_curthooks(cfg, target, state)
+      sys.exit(0)
+    else:
+      LOG.info("Running custom curtin hooks")
+    state_etcd = os.path.split(state['fstab'])[0]
+    machine = platform.machine()
+
+    distro_info = distro.get_distroinfo(target=target)
+    if not distro_info:
+        raise RuntimeError('Failed to determine target distro')
+    osfamily = distro_info.family
+    LOG.info('Configuring target system for distro: %s osfamily: %s',
+             distro_info.variant, osfamily)
+
+    sources = cfg.get('sources', {})
+    dd_image = len(util.get_dd_images(sources)) > 0
+
+    curthooks.disable_overlayroot(cfg, target)
+    curthooks.disable_update_initramfs(cfg, target, machine)
+
+    if not dd_image:
+        curthooks.configure_iscsi(cfg, state_etcd, target, osfamily=osfamily)
+        curthooks.configure_mdadm(cfg, state_etcd, target, osfamily=osfamily)
+        curthooks.copy_fstab(state.get('fstab'), target)
+        curthooks.add_swap(cfg, target, state.get('fstab'))
+
+    curthooks.apply_networking(target, state)
+    curthooks.handle_pollinate_user_agent(cfg, target)
+
+    # set cloud-init maas datasource
+    if cfg.get('cloudconfig'):
+        curthooks.handle_cloudconfig(
+                      cfg['cloudconfig'],
+                      base_dir=target_path(target,
+                                                 'etc/cloud/cloud.cfg.d'))
+
+    run_hook_in_target(target, 'setup-bootloader')
+
+def cleanup():
+    """Remove curtin-hooks so its as if we were never here."""
+    curtin_dir = os.path.dirname(__file__)
+    shutil.rmtree(curtin_dir)
+
+
+def main():
+    state = load_command_environment()
+    config = load_command_config(None, state)
+    target = state['target']
+
+    curthook(config, target, state)
+    cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/alma10/curtin/setup-bootloader
+++ b/alma10/curtin/setup-bootloader
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Update All initramfs files
+for kernel in $(ls /lib/modules/); do
+  dracut --force /boot/initramfs-${kernel}.img ${kernel}
+done
+
+# Reinstall shim
+dnf reinstall -y shim-*
+
+# Generate the GRUB config file
+mkdir -p /boot/efi/EFI/almalinux/
+grub2-mkconfig -o /boot/efi/EFI/almalinux/grub.cfg
+
+# Install GRUB and update the configuration
+if [ -d /sys/firmware/efi/efivars/ ]; then
+        # Fix boot delays due to PXE loop
+        cp /boot/efi/EFI/almalinux/grub* /boot/efi/EFI/boot/
+        cp /boot/efi/EFI/almalinux/*.efi /boot/efi/EFI/boot/
+else
+        grub_dev="/dev/$(lsblk -r | grep 'part /$' | awk '{print $1}' | sed s/[0-9]//g)"
+
+        grub2-install \
+            --target=i386-pc \
+            --recheck ${grub_dev}
+fi
+exit 0

--- a/alma10/http/alma10.ks.pkrtpl.hcl
+++ b/alma10/http/alma10.ks.pkrtpl.hcl
@@ -87,7 +87,7 @@ chmod 440 /etc/sudoers.d/alma
 
 %end
 
-%packages
+%packages --ignoremissing
 @Core
 bash-completion
 cloud-init
@@ -96,9 +96,10 @@ rsync
 tar
 patch
 yum-utils
-grub2-efi-x64
-shim-x64
-grub2-efi-x64-modules
+grub2-pc
+grub2-efi-*
+shim-*
+grub2-efi-*-modules
 efibootmgr
 dosfstools
 lvm2

--- a/alma8/Makefile
+++ b/alma8/Makefile
@@ -5,8 +5,27 @@ include ../scripts/check.mk
 PACKER ?= packer
 PACKER_LOG ?= 0
 TIMEOUT ?= 1h
+ARCH ?= x86_64
+
+# Detect if running on ARM host
+ifeq ($(shell uname -m),aarch64)
+    HOST_IS_ARM = true
+else
+    HOST_IS_ARM = false
+endif
+
+ifeq ($(wildcard /usr/share/OVMF/OVMF_CODE.fd),)
+	OVMF_SFX ?= _4M
+else
+	OVMF_SFX ?=
+endif
 
 export PACKER_LOG
+
+# Fallback
+ifeq ($(strip $(ARCH)),amd64)
+	ARCH = x86_64
+endif
 
 .PHONY: all clean
 
@@ -14,8 +33,30 @@ all: alma8.tar.gz
 
 $(eval $(call check_packages_deps))
 
-alma8.tar.gz: check-deps clean
-	${PACKER} init alma8.pkr.hcl && ${PACKER} build -var timeout=${TIMEOUT} alma8.pkr.hcl
+lint:
+	packer validate .
+	packer fmt -check -diff .
+
+format:
+	packer fmt .
+
+OVMF_VARS.fd: /usr/share/OVMF/OVMF_VARS${OVMF_SFX}.fd
+	cp -v $< ${ARCH}_VARS.fd
+
+SIZE_VARS.fd:
+ifeq ($(strip $(ARCH)),aarch64)
+	truncate -s 64m ${ARCH}_VARS.fd
+else
+	truncate -s 2m ${ARCH}_VARS.fd
+endif
+
+alma8.tar.gz: check-deps clean OVMF_VARS.fd SIZE_VARS.fd
+	${PACKER} init alma8.pkr.hcl && ${PACKER} build \
+		-var architecture=${ARCH} \
+		-var host_is_arm=${HOST_IS_ARM} \
+		-var timeout=${TIMEOUT} \
+		-var ovmf_suffix=${OVMF_SFX} \
+		alma8.pkr.hcl
 
 clean:
-	${RM} -rf output-alma8 alma8.tar.gz
+	${RM} -rf *.fd output-alma8 alma8.tar.gz

--- a/alma8/alma8.pkr.hcl
+++ b/alma8/alma8.pkr.hcl
@@ -14,37 +14,6 @@ variable "filename" {
   description = "The filename of the tarball to produce"
 }
 
-variable "alma_iso_url" {
-  type    = string
-  default = "https://repo.almalinux.org/almalinux/8/isos/x86_64/AlmaLinux-8-latest-x86_64-boot.iso"
-}
-
-variable "alma_sha256sum_url" {
-  type    = string
-  default = "https://repo.almalinux.org/almalinux/8/isos/x86_64/CHECKSUM"
-}
-
-# use can use "--url" to specify the exact url for os repo
-# for ex. "--url='https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os'"
-variable "ks_os_repos" {
-  type    = string
-  default = "--mirrorlist='https://mirrors.almalinux.org/mirrorlist/8/baseos'"
-}
-
-# Use --baseurl to specify the exact url for appstream repo
-# for ex. "--baseurl='https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os'"
-variable "ks_appstream_repos" {
-  type    = string
-  default = "--mirrorlist='https://mirrors.almalinux.org/mirrorlist/8/appstream'"
-}
-
-# Use --baseurl to specify the exact url for extras repo
-# for ex. "--baseurl='https://repo.almalinux.org/almalinux/8/extras/x86_64/os'"
-variable "ks_extras_repos" {
-  type    = string
-  default = "--mirrorlist='https://mirrors.almalinux.org/mirrorlist/8/extras'"
-}
-
 variable ks_proxy {
   type    = string
   default = "${env("KS_PROXY")}"
@@ -61,23 +30,83 @@ variable "timeout" {
   description = "Timeout for building the image"
 }
 
+variable "architecture" {
+  type        = string
+  default     = "amd64"
+  description = "The architecture to build the image for (amd64 or arm64)"
+}
+
+variable "host_is_arm" {
+  type        = bool
+  default     = false
+  description = "The host architecture is aarch64"
+}
+
+variable "ovmf_suffix" {
+  type        = string
+  default     = ""
+  description = "Suffix for OVMF CODE and VARS files. Newer systems such as Noble use _4M."
+}
+
 locals {
+  qemu_arch = {
+    "x86_64"  = "x86_64"
+    "aarch64" = "aarch64"
+  }
+  uefi_imp = {
+    "x86_64"  = "OVMF"
+    "aarch64" = "AAVMF"
+  }
+  uefi_sfx = {
+    "x86_64"  = "${var.ovmf_suffix}"
+    "aarch64" = ""
+  }
+  qemu_machine = {
+    "x86_64"  = "accel=kvm"
+    "aarch64" = var.host_is_arm ? "virt,accel=kvm" : "virt"
+  }
+  qemu_cpu = {
+    "x86_64"  = "host"
+    "aarch64" = var.host_is_arm ? "host" : "max"
+  }
+
   ks_proxy           = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
-  ks_os_repos        = var.ks_mirror != "" ? "--url=${var.ks_mirror}/BaseOS/x86_64/os" : var.ks_os_repos
-  ks_appstream_repos = var.ks_mirror != "" ? "--baseurl=${var.ks_mirror}/AppStream/x86_64/os" : var.ks_appstream_repos
-  ks_extras_repos    = var.ks_mirror != "" ? "--baseurl=${var.ks_mirror}/extras/x86_64/os" : var.ks_extras_repos
+  ks_os_repos        = var.ks_mirror != "" ? "--url=${var.ks_mirror}/BaseOS/${var.architecture}/os" : "--mirrorlist='https://mirrors.almalinux.org/mirrorlist/8/baseos'"
+  ks_appstream_repos = var.ks_mirror != "" ? "--baseurl=${var.ks_mirror}/AppStream/${var.architecture}/os" : "--mirrorlist='https://mirrors.almalinux.org/mirrorlist/8/appstream'"
+  ks_extras_repos    = var.ks_mirror != "" ? "--baseurl=${var.ks_mirror}/extras/${var.architecture}/os" : "--mirrorlist='https://mirrors.almalinux.org/mirrorlist/8/extras'"
 }
 
 source "qemu" "alma8" {
-  boot_command     = ["<up><tab> ", "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/alma8.ks ", "console=ttyS0 inst.cmdline", "<enter>"]
-  boot_wait        = "3s"
+  boot_command     = ["<up><wait>", "e", "<down><down><down><left>", " console=ttyS0 inst.cmdline inst.text inst.ks=http://{{.HTTPIP}}:{{.HTTPPort}}/alma8.ks <f10>"]
+  boot_wait        = "5s"
   communicator     = "none"
-  disk_size        = "4G"
+  disk_size        = "45G"
+  format           = "qcow2"
   headless         = true
-  iso_checksum     = "file:${var.alma_sha256sum_url}"
-  iso_url          = var.alma_iso_url
+  iso_checksum     = "file:https://repo.almalinux.org/almalinux/8/isos/${var.architecture}/CHECKSUM"
+  iso_url          = "https://repo.almalinux.org/almalinux/8/isos/${var.architecture}/AlmaLinux-8-latest-${var.architecture}-boot.iso"
+  iso_target_path  = "packer_cache/AlmaLinux-8-latest-${var.architecture}-boot.iso"
   memory           = 2048
-  qemuargs         = [["-serial", "stdio"]]
+  cores            = 4
+  qemu_binary      = "qemu-system-${lookup(local.qemu_arch, var.architecture, "")}"
+  qemuargs = [
+    ["-serial", "stdio"],
+    ["-boot", "strict=off"],
+    ["-device", "qemu-xhci"],
+    ["-device", "usb-kbd"],
+    ["-device", "virtio-net-pci,netdev=net0"],
+    ["-netdev", "user,id=net0"],
+    ["-device", "virtio-blk-pci,drive=drive0,bootindex=0"],
+    ["-device", "virtio-blk-pci,drive=cdrom0,bootindex=1"],
+    ["-machine", "${lookup(local.qemu_machine, var.architecture, "")}"],
+    ["-cpu", "${lookup(local.qemu_cpu, var.architecture, "")}"],
+    ["-device", "virtio-gpu-pci"],
+    ["-global", "driver=cfi.pflash01,property=secure,value=off"],
+    ["-drive", "if=pflash,format=raw,unit=0,id=ovmf_code,readonly=on,file=/usr/share/${lookup(local.uefi_imp, var.architecture, "")}/${lookup(local.uefi_imp, var.architecture, "")}_CODE${lookup(local.uefi_sfx, var.architecture, "")}.fd"],
+    ["-drive", "if=pflash,format=raw,unit=1,id=ovmf_vars,file=${var.architecture}_VARS.fd"],
+    ["-drive", "file=output-alma8/packer-alma8,if=none,id=drive0,cache=writeback,discard=ignore,format=qcow2"],
+    ["-drive", "file=packer_cache/AlmaLinux-8-latest-${var.architecture}-boot.iso,if=none,id=cdrom0,media=cdrom"]
+  ]
   shutdown_timeout = var.timeout
   http_content = {
     "/alma8.ks" = templatefile("${path.root}/http/alma8.ks.pkrtpl.hcl",

--- a/alma8/curtin/curtin-hooks
+++ b/alma8/curtin/curtin-hooks
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import os
+import shutil
+import platform
+import sys
+
+from curtin import distro, util
+from curtin.config import load_command_config
+from curtin.log import LOG
+from curtin.paths import target_path
+from curtin.util import load_command_environment, ChrootableTarget
+from curtin.commands import curthooks
+
+def run_hook_in_target(target, hook):
+    """Look for "hook" in "target" and run in a chroot"""
+    target_hook = target_path(target, '/curtin/' + hook)
+    if os.path.isfile(target_hook):
+        LOG.debug("running %s" % target_hook)
+        with ChrootableTarget(target=target) as in_chroot:
+            in_chroot.subp(['/curtin/' + hook])
+        return True
+    return False
+
+def curthook(cfg, target, state):
+    """Configure network and bootloader"""
+    if "almalinux" in distro.DISTRO_NAMES:
+      LOG.info("Native Curtin support is available, running builtin hooks")
+      curthooks.builtin_curthooks(cfg, target, state)
+      sys.exit(0)
+    else:
+      LOG.info("Running custom curtin hooks")
+    state_etcd = os.path.split(state['fstab'])[0]
+    machine = platform.machine()
+
+    distro_info = distro.get_distroinfo(target=target)
+    if not distro_info:
+        raise RuntimeError('Failed to determine target distro')
+    osfamily = distro_info.family
+    LOG.info('Configuring target system for distro: %s osfamily: %s',
+             distro_info.variant, osfamily)
+
+    sources = cfg.get('sources', {})
+    dd_image = len(util.get_dd_images(sources)) > 0
+
+    curthooks.disable_overlayroot(cfg, target)
+    curthooks.disable_update_initramfs(cfg, target, machine)
+
+    if not dd_image:
+        curthooks.configure_iscsi(cfg, state_etcd, target, osfamily=osfamily)
+        curthooks.configure_mdadm(cfg, state_etcd, target, osfamily=osfamily)
+        curthooks.copy_fstab(state.get('fstab'), target)
+        curthooks.add_swap(cfg, target, state.get('fstab'))
+
+    curthooks.apply_networking(target, state)
+    curthooks.handle_pollinate_user_agent(cfg, target)
+
+    # set cloud-init maas datasource
+    if cfg.get('cloudconfig'):
+        curthooks.handle_cloudconfig(
+                      cfg['cloudconfig'],
+                      base_dir=target_path(target,
+                                                 'etc/cloud/cloud.cfg.d'))
+
+    run_hook_in_target(target, 'setup-bootloader')
+
+def cleanup():
+    """Remove curtin-hooks so its as if we were never here."""
+    curtin_dir = os.path.dirname(__file__)
+    shutil.rmtree(curtin_dir)
+
+
+def main():
+    state = load_command_environment()
+    config = load_command_config(None, state)
+    target = state['target']
+
+    curthook(config, target, state)
+    cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/alma8/curtin/setup-bootloader
+++ b/alma8/curtin/setup-bootloader
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Update All initramfs files
+for kernel in $(ls /lib/modules/); do
+  dracut --force /boot/initramfs-${kernel}.img ${kernel}
+done
+
+# Reinstall shim
+dnf reinstall -y shim-*
+
+# Generate the GRUB config file
+mkdir -p /boot/efi/EFI/almalinux/
+grub2-mkconfig -o /boot/efi/EFI/almalinux/grub.cfg
+
+# Install GRUB and update the configuration
+if [ -d /sys/firmware/efi/efivars/ ]; then
+        # Fix boot delays due to PXE loop
+        cp /boot/efi/EFI/almalinux/grub* /boot/efi/EFI/boot/
+        cp /boot/efi/EFI/almalinux/*.efi /boot/efi/EFI/boot/
+else
+        grub_dev="/dev/$(lsblk -r | grep 'part /$' | awk '{print $1}' | sed s/[0-9]//g)"
+
+        grub2-install \
+            --target=i386-pc \
+            --recheck ${grub_dev}
+fi
+exit 0

--- a/alma8/http/alma8.ks.pkrtpl.hcl
+++ b/alma8/http/alma8.ks.pkrtpl.hcl
@@ -28,8 +28,8 @@ skipx
 # Initial disk setup
 # Use the first paravirtualized disk
 ignoredisk --only-use=vda
-# Place the bootloader on the Master Boot Record
-bootloader --location=mbr --driveorder="vda" --timeout=1
+# No need for bootloader
+bootloader --disabled
 # Wipe invalid partition tables
 zerombr
 # Erase all partitions and assign default labels
@@ -87,7 +87,7 @@ chmod 440 /etc/sudoers.d/alma
 
 %end
 
-%packages
+%packages --ignoremissing
 @Core
 bash-completion
 cloud-init
@@ -96,9 +96,10 @@ rsync
 tar
 patch
 yum-utils
-grub2-efi-x64
-shim-x64
-grub2-efi-x64-modules
+grub2-pc
+grub2-efi-*
+shim-*
+grub2-efi-*-modules
 efibootmgr
 dosfstools
 lvm2

--- a/alma9/Makefile
+++ b/alma9/Makefile
@@ -5,8 +5,27 @@ include ../scripts/check.mk
 PACKER ?= packer
 PACKER_LOG ?= 0
 TIMEOUT ?= 1h
+ARCH ?= x86_64
+
+# Detect if running on ARM host
+ifeq ($(shell uname -m),aarch64)
+    HOST_IS_ARM = true
+else
+    HOST_IS_ARM = false
+endif
+
+ifeq ($(wildcard /usr/share/OVMF/OVMF_CODE.fd),)
+	OVMF_SFX ?= _4M
+else
+	OVMF_SFX ?=
+endif
 
 export PACKER_LOG
+
+# Fallback
+ifeq ($(strip $(ARCH)),amd64)
+	ARCH = x86_64
+endif
 
 .PHONY: all clean
 
@@ -14,8 +33,30 @@ all: alma9.tar.gz
 
 $(eval $(call check_packages_deps))
 
-alma9.tar.gz: check-deps clean
-	${PACKER} init alma9.pkr.hcl && ${PACKER} build -var timeout=${TIMEOUT} alma9.pkr.hcl
+lint:
+	packer validate .
+	packer fmt -check -diff .
+
+format:
+	packer fmt .
+
+OVMF_VARS.fd: /usr/share/OVMF/OVMF_VARS${OVMF_SFX}.fd
+	cp -v $< ${ARCH}_VARS.fd
+
+SIZE_VARS.fd:
+ifeq ($(strip $(ARCH)),aarch64)
+	truncate -s 64m ${ARCH}_VARS.fd
+else
+	truncate -s 2m ${ARCH}_VARS.fd
+endif
+
+alma9.tar.gz: check-deps clean OVMF_VARS.fd SIZE_VARS.fd
+	${PACKER} init alma9.pkr.hcl && ${PACKER} build \
+		-var architecture=${ARCH} \
+		-var host_is_arm=${HOST_IS_ARM} \
+		-var timeout=${TIMEOUT} \
+		-var ovmf_suffix=${OVMF_SFX} \
+		alma9.pkr.hcl
 
 clean:
-	${RM} -rf output-alma9 alma9.tar.gz
+	${RM} -rf *.fd output-alma9 alma9.tar.gz

--- a/alma9/alma9.pkr.hcl
+++ b/alma9/alma9.pkr.hcl
@@ -14,43 +14,6 @@ variable "filename" {
   description = "The filename of the tarball to produce"
 }
 
-variable "headless" {
-  type        = bool
-  default     = true
-  description = "Whether VNC viewer should not be launched."
-}
-
-variable "alma_iso_url" {
-  type    = string
-  default = "https://repo.almalinux.org/almalinux/9/isos/x86_64/AlmaLinux-9-latest-x86_64-boot.iso"
-}
-
-variable "alma_sha256sum_url" {
-  type    = string
-  default = "https://repo.almalinux.org/almalinux/9/isos/x86_64/CHECKSUM"
-}
-
-# use can use "--url" to specify the exact url for os repo
-# for ex. "--url='https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os'"
-variable "ks_os_repos" {
-  type    = string
-  default = "--mirrorlist='https://mirrors.almalinux.org/mirrorlist/9/baseos'"
-}
-
-# Use --baseurl to specify the exact url for appstream repo
-# for ex. "--baseurl='https://repo.almalinux.org/almalinux/9/AppStream/x86_64/os'"
-variable "ks_appstream_repos" {
-  type    = string
-  default = "--mirrorlist='https://mirrors.almalinux.org/mirrorlist/9/appstream'"
-}
-
-# Use --baseurl to specify the exact url for extras repo
-# for ex. "--baseurl='https://repo.almalinux.org/almalinux/9/extras/x86_64/os'"
-variable "ks_extras_repos" {
-  type    = string
-  default = "--mirrorlist='https://mirrors.almalinux.org/mirrorlist/9/extras'"
-}
-
 variable ks_proxy {
   type    = string
   default = "${env("KS_PROXY")}"
@@ -67,23 +30,83 @@ variable "timeout" {
   description = "Timeout for building the image"
 }
 
+variable "architecture" {
+  type        = string
+  default     = "amd64"
+  description = "The architecture to build the image for (amd64 or arm64)"
+}
+
+variable "host_is_arm" {
+  type        = bool
+  default     = false
+  description = "The host architecture is aarch64"
+}
+
+variable "ovmf_suffix" {
+  type        = string
+  default     = ""
+  description = "Suffix for OVMF CODE and VARS files. Newer systems such as Noble use _4M."
+}
+
 locals {
+  qemu_arch = {
+    "x86_64"  = "x86_64"
+    "aarch64" = "aarch64"
+  }
+  uefi_imp = {
+    "x86_64"  = "OVMF"
+    "aarch64" = "AAVMF"
+  }
+  uefi_sfx = {
+    "x86_64"  = "${var.ovmf_suffix}"
+    "aarch64" = ""
+  }
+  qemu_machine = {
+    "x86_64"  = "accel=kvm"
+    "aarch64" = var.host_is_arm ? "virt,accel=kvm" : "virt"
+  }
+  qemu_cpu = {
+    "x86_64"  = "host"
+    "aarch64" = var.host_is_arm ? "host" : "max"
+  }
+
   ks_proxy           = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
-  ks_os_repos        = var.ks_mirror != "" ? "--url=${var.ks_mirror}/BaseOS/x86_64/os" : var.ks_os_repos
-  ks_appstream_repos = var.ks_mirror != "" ? "--baseurl=${var.ks_mirror}/AppStream/x86_64/os" : var.ks_appstream_repos
-  ks_extras_repos    = var.ks_mirror != "" ? "--baseurl=${var.ks_mirror}/extras/x86_64/os" : var.ks_extras_repos
+  ks_os_repos        = var.ks_mirror != "" ? "--url=${var.ks_mirror}/BaseOS/${var.architecture}/os" : "--mirrorlist='https://mirrors.almalinux.org/mirrorlist/9/baseos'"
+  ks_appstream_repos = var.ks_mirror != "" ? "--baseurl=${var.ks_mirror}/AppStream/${var.architecture}/os" : "--mirrorlist='https://mirrors.almalinux.org/mirrorlist/9/appstream'"
+  ks_extras_repos    = var.ks_mirror != "" ? "--baseurl=${var.ks_mirror}/extras/${var.architecture}/os" : "--mirrorlist='https://mirrors.almalinux.org/mirrorlist/9/extras'"
 }
 
 source "qemu" "alma9" {
-  boot_command     = ["<up><tab> ", "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/alma9.ks ", "console=ttyS0 inst.cmdline", "<enter>"]
-  boot_wait        = "3s"
+  boot_command     = ["<up><wait>", "e", "<down><down><down><left>", " console=ttyS0 inst.cmdline inst.text inst.ks=http://{{.HTTPIP}}:{{.HTTPPort}}/alma9.ks <f10>"]
+  boot_wait        = "5s"
   communicator     = "none"
-  disk_size        = "4G"
-  headless         = var.headless
-  iso_checksum     = "file:${var.alma_sha256sum_url}"
-  iso_url          = "${var.alma_iso_url}"
+  disk_size        = "45G"
+  format           = "qcow2"
+  headless         = true
+  iso_checksum     = "file:https://repo.almalinux.org/almalinux/9/isos/${var.architecture}/CHECKSUM"
+  iso_url          = "https://repo.almalinux.org/almalinux/9/isos/${var.architecture}/AlmaLinux-9-latest-${var.architecture}-boot.iso"
+  iso_target_path  = "packer_cache/AlmaLinux-9-latest-${var.architecture}-boot.iso"
   memory           = 2048
-  qemuargs         = [["-serial", "stdio"], ["-cpu", "host"]]
+  cores            = 4
+  qemu_binary      = "qemu-system-${lookup(local.qemu_arch, var.architecture, "")}"
+  qemuargs = [
+    ["-serial", "stdio"],
+    ["-boot", "strict=off"],
+    ["-device", "qemu-xhci"],
+    ["-device", "usb-kbd"],
+    ["-device", "virtio-net-pci,netdev=net0"],
+    ["-netdev", "user,id=net0"],
+    ["-device", "virtio-blk-pci,drive=drive0,bootindex=0"],
+    ["-device", "virtio-blk-pci,drive=cdrom0,bootindex=1"],
+    ["-machine", "${lookup(local.qemu_machine, var.architecture, "")}"],
+    ["-cpu", "${lookup(local.qemu_cpu, var.architecture, "")}"],
+    ["-device", "virtio-gpu-pci"],
+    ["-global", "driver=cfi.pflash01,property=secure,value=off"],
+    ["-drive", "if=pflash,format=raw,unit=0,id=ovmf_code,readonly=on,file=/usr/share/${lookup(local.uefi_imp, var.architecture, "")}/${lookup(local.uefi_imp, var.architecture, "")}_CODE${lookup(local.uefi_sfx, var.architecture, "")}.fd"],
+    ["-drive", "if=pflash,format=raw,unit=1,id=ovmf_vars,file=${var.architecture}_VARS.fd"],
+    ["-drive", "file=output-alma9/packer-alma9,if=none,id=drive0,cache=writeback,discard=ignore,format=qcow2"],
+    ["-drive", "file=packer_cache/AlmaLinux-9-latest-${var.architecture}-boot.iso,if=none,id=cdrom0,media=cdrom"]
+  ]
   shutdown_timeout = var.timeout
   http_content = {
     "/alma9.ks" = templatefile("${path.root}/http/alma9.ks.pkrtpl.hcl",
@@ -102,7 +125,7 @@ build {
 
   post-processor "shell-local" {
     inline = [
-      "SOURCE=alma9",
+      "SOURCE=${source.name}",
       "OUTPUT=${var.filename}",
       "source ../scripts/fuse-nbd",
       "source ../scripts/fuse-tar-root",

--- a/alma9/curtin/curtin-hooks
+++ b/alma9/curtin/curtin-hooks
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import os
+import shutil
+import platform
+import sys
+
+from curtin import distro, util
+from curtin.config import load_command_config
+from curtin.log import LOG
+from curtin.paths import target_path
+from curtin.util import load_command_environment, ChrootableTarget
+from curtin.commands import curthooks
+
+def run_hook_in_target(target, hook):
+    """Look for "hook" in "target" and run in a chroot"""
+    target_hook = target_path(target, '/curtin/' + hook)
+    if os.path.isfile(target_hook):
+        LOG.debug("running %s" % target_hook)
+        with ChrootableTarget(target=target) as in_chroot:
+            in_chroot.subp(['/curtin/' + hook])
+        return True
+    return False
+
+def curthook(cfg, target, state):
+    """Configure network and bootloader"""
+    if "almalinux" in distro.DISTRO_NAMES:
+      LOG.info("Native Curtin support is available, running builtin hooks")
+      curthooks.builtin_curthooks(cfg, target, state)
+      sys.exit(0)
+    else:
+      LOG.info("Running custom curtin hooks")
+    state_etcd = os.path.split(state['fstab'])[0]
+    machine = platform.machine()
+
+    distro_info = distro.get_distroinfo(target=target)
+    if not distro_info:
+        raise RuntimeError('Failed to determine target distro')
+    osfamily = distro_info.family
+    LOG.info('Configuring target system for distro: %s osfamily: %s',
+             distro_info.variant, osfamily)
+
+    sources = cfg.get('sources', {})
+    dd_image = len(util.get_dd_images(sources)) > 0
+
+    curthooks.disable_overlayroot(cfg, target)
+    curthooks.disable_update_initramfs(cfg, target, machine)
+
+    if not dd_image:
+        curthooks.configure_iscsi(cfg, state_etcd, target, osfamily=osfamily)
+        curthooks.configure_mdadm(cfg, state_etcd, target, osfamily=osfamily)
+        curthooks.copy_fstab(state.get('fstab'), target)
+        curthooks.add_swap(cfg, target, state.get('fstab'))
+
+    curthooks.apply_networking(target, state)
+    curthooks.handle_pollinate_user_agent(cfg, target)
+
+    # set cloud-init maas datasource
+    if cfg.get('cloudconfig'):
+        curthooks.handle_cloudconfig(
+                      cfg['cloudconfig'],
+                      base_dir=target_path(target,
+                                                 'etc/cloud/cloud.cfg.d'))
+
+    run_hook_in_target(target, 'setup-bootloader')
+
+def cleanup():
+    """Remove curtin-hooks so its as if we were never here."""
+    curtin_dir = os.path.dirname(__file__)
+    shutil.rmtree(curtin_dir)
+
+
+def main():
+    state = load_command_environment()
+    config = load_command_config(None, state)
+    target = state['target']
+
+    curthook(config, target, state)
+    cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/alma9/curtin/setup-bootloader
+++ b/alma9/curtin/setup-bootloader
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Update All initramfs files
+for kernel in $(ls /lib/modules/); do
+  dracut --force /boot/initramfs-${kernel}.img ${kernel}
+done
+
+# Reinstall shim
+dnf reinstall -y shim-*
+
+# Generate the GRUB config file
+mkdir -p /boot/efi/EFI/almalinux/
+grub2-mkconfig -o /boot/efi/EFI/almalinux/grub.cfg
+
+# Install GRUB and update the configuration
+if [ -d /sys/firmware/efi/efivars/ ]; then
+        # Fix boot delays due to PXE loop
+        cp /boot/efi/EFI/almalinux/grub* /boot/efi/EFI/boot/
+        cp /boot/efi/EFI/almalinux/*.efi /boot/efi/EFI/boot/
+else
+        grub_dev="/dev/$(lsblk -r | grep 'part /$' | awk '{print $1}' | sed s/[0-9]//g)"
+
+        grub2-install \
+            --target=i386-pc \
+            --recheck ${grub_dev}
+fi
+exit 0

--- a/alma9/http/alma9.ks.pkrtpl.hcl
+++ b/alma9/http/alma9.ks.pkrtpl.hcl
@@ -28,8 +28,8 @@ skipx
 # Initial disk setup
 # Use the first paravirtualized disk
 ignoredisk --only-use=vda
-# Place the bootloader on the Master Boot Record
-bootloader --location=mbr --driveorder="vda" --timeout=1
+# No need for bootloader
+bootloader --disabled
 # Wipe invalid partition tables
 zerombr
 # Erase all partitions and assign default labels
@@ -87,7 +87,7 @@ chmod 440 /etc/sudoers.d/alma
 
 %end
 
-%packages
+%packages --ignoremissing
 @Core
 bash-completion
 cloud-init
@@ -96,9 +96,10 @@ rsync
 tar
 patch
 yum-utils
-grub2-efi-x64
-shim-x64
-grub2-efi-x64-modules
+grub2-pc
+grub2-efi-*
+shim-*
+grub2-efi-*-modules
 efibootmgr
 dosfstools
 lvm2


### PR DESCRIPTION
AlmaLinux Overhaul (#349):

- Added proper aarch64 support to AlmaLinux 8, 9 and 10
- Added custom curtin hooks to support MAAS 3.3 and later
- Updated main README.md to reflect the above.