### PR TITLE
Minor Fixes for Ubuntu and a README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,9 @@ Refer to the `README.md` inside each OS directory for supported parameters.
 ## Best practices for uploading images
 
 - Follow examples in each OS’s `README.md`.  
+- The `name` parameter is formatted as `prefix/os-name`. The `os-name` can include dashes, dots and numbers but no space and special characters.
 - Use **unique names** for images to avoid cache collisions.  
-- Keep `title` values descriptive (quoted strings).  
+- The `title` parameter is free text format as long as enclosed in quotes.
 - Upload from a machine close to the MAAS region controller to reduce latency.  
 - Test images on a small scale before wide deployment.  
 

--- a/ubuntu/ubuntu-flat.pkr.hcl
+++ b/ubuntu/ubuntu-flat.pkr.hcl
@@ -1,6 +1,6 @@
 source "qemu" "flat" {
   boot_command    = ["<wait>e<wait5>", "<down><wait><down><wait><down><wait2><end><wait5>", "<bs><bs><bs><bs><wait> autoinstall ---<wait><f10>"]
-  boot_wait       = "10s"
+  boot_wait       = "2s"
   cpus            = 2
   disk_size       = "8G"
   format          = "raw"

--- a/ubuntu/ubuntu-lvm.pkr.hcl
+++ b/ubuntu/ubuntu-lvm.pkr.hcl
@@ -1,6 +1,6 @@
 source "qemu" "lvm" {
   boot_command    = ["<wait>e<wait5>", "<down><wait><down><wait><down><wait2><end><wait5>", "<bs><bs><bs><bs><wait>autoinstall ---<wait><f10>"]
-  boot_wait       = "10s"
+  boot_wait       = "2s"
   cpus            = 2
   disk_size       = "8G"
   format          = "raw"


### PR DESCRIPTION
Ubuntu:
- Adjust the boot_wait time in flat and lvm templates to make them work with Focal ISO images.

README.md:
- Updated the best practices section.