### PR TITLE
SLES16 Updates

### DIFF
--- a/sles16/README.md
+++ b/sles16/README.md
@@ -44,12 +44,14 @@ journalctl -u agama-auto
 ```
 ## Known Issues
 
-* As of March 2025, with SLES16-Beta1 ISO, the cloud-init package is missing
+* As of December 2025, with SLES16-Beta2 ISO, the cloud-init package is missing
 from the installation DVD. Until this is resolved, we have a workaround to
-download a copy of the package from OpenSUSE online repositories.
+download and install the package from OpenSUSE online repositories.
 
-* Due to lack of access to aarch64 ISO images, we have not been able to test
-the build process with tis architecture yet.
+* REGRESSION: We observed an auto-installer regression with the release of the final 16.0
+ISO images and the issue was reported here: https://bugzilla.suse.com/show_bug.cgi?id=1255014
+The current workaround is to use the Beta2 ISO to build the images which in turn installs
+the available updates during the build and the resulting image should be the same as 16.0.
 
 ## Building the image using a proxy
 

--- a/sles16/curtin/setup-bootloader
+++ b/sles16/curtin/setup-bootloader
@@ -14,7 +14,7 @@ grub2-mkconfig -o /boot/grub2/grub.cfg
 if [ -d /sys/firmware/efi/efivars/ ]; then
         shim-install
         # Set Next Boot to be SLES
-        efibootmgr --bootnext $(sudo efibootmgr -v | grep sles | awk '{print $1}' | sed s/'[^0-9]'//g)
+        efibootmgr --bootnext $(efibootmgr -v | grep sles | awk '{print $1}' | sed s/'[^0-9]'//g)
         # Fix boot delays due to PXE loop
         cp /boot/efi/EFI/sles/grub.* /boot/efi/EFI/boot/
 else

--- a/sles16/sles.pkr.hcl
+++ b/sles16/sles.pkr.hcl
@@ -70,7 +70,7 @@ source "qemu" "sles16" {
   boot_command      = ["e", "<down><down><down><down>", "<end><wait>", "<spacebar>", "agama.auto=http://{{ .HTTPIP }}:{{ .HTTPPort }}/profile.json<wait>","<leftCtrlOn>x<leftCtrlOff>"]
   boot_wait        = "5s"
   communicator     = "none"
-  disk_size        = "8G"
+  disk_size        = "20G"
   format           = "qcow2"
   headless         = true
   iso_checksum     = "none"
@@ -99,6 +99,7 @@ source "qemu" "sles16" {
     ["-drive", "file=${var.sles16_iso_path},if=none,id=cdrom0,media=cdrom"]
   ]
   shutdown_timeout = var.timeout
+  vnc_bind_address = "0.0.0.0"
   http_content = {
     "/profile.json" = templatefile("${path.root}/http/profile.json.pkrtpl.hcl",
       {


### PR DESCRIPTION
SLES16:
- Improve the Agama template to capture the latest cloud-init package and run updates during the build process.
- Updated README and mentioned the Agama regression https://bugzilla.suse.com/show_bug.cgi?id=1255014
- Increase the build disk size to 20G and set VNC listen to 0.0.0.0
- Use minimal_base vs. base product trim