### PR TITLE
fix: ubuntu LVM builds fixup

### DIFF
--- a/ubuntu/scripts/cleanup.sh
+++ b/ubuntu/scripts/cleanup.sh
@@ -26,5 +26,7 @@ cloud-init clean --logs
 apt-get autoremove --purge -yq
 apt-get clean -yq
 
-# Cleanup fstab
-rm -r /etc/fstab
+# Cleanup fstab on non-LVM builds
+if [ $(lsblk | grep -c ubuntu--vg-ubuntu--lv) -eq 0 ]; then
+    rm -r /etc/fstab
+fi


### PR DESCRIPTION
scripts/cleanup.sh:
- Do not delete /etc/fstab on LVM builds.
- This causes LVN deployments to fail.