### PR TITLE
Bluefield: add customization example for DOCA 3.3.0

### DIFF
--- a/ubuntu/README.md
+++ b/ubuntu/README.md
@@ -103,6 +103,7 @@ a DOCA release lower than `3.2.0`.
 ```shell
 make custom-cloudimg.tar.gz SERIES=jammy ARCH=arm64 CUSTOMIZE=scripts/examples/bluefield-doca-2-9-3.sh
 make custom-cloudimg.tar.gz SERIES=noble ARCH=arm64 CUSTOMIZE=scripts/examples/bluefield-doca-3-2-1.sh
+make custom-cloudimg.tar.gz SERIES=noble ARCH=arm64 CUSTOMIZE=scripts/examples/bluefield-doca-3-3-0.sh
 ```
 
 ## ubuntu-flat.pkr.hcl and ubuntu-lvm.pkr.hcl

--- a/ubuntu/scripts/examples/README.md
+++ b/ubuntu/scripts/examples/README.md
@@ -1,0 +1,17 @@
+# BlueField Customization Scripts
+
+This directory contains example customization scripts for building
+BlueField DPU images with packer-maas.
+
+| Script | DOCA | BSP | Kernel | Series | Notes |
+|--------|------|-----|--------|--------|-------|
+| `bluefield-doca-2-9-3.sh` | 2.9.3 | 4.13.1-13827 | 6.8.0-1013 | jammy | Uses GPG key verification |
+| `bluefield-doca-3-2-1.sh` | 3.2.1 | 4.13.1-13827 | 6.8.0-1013 | noble | Uses GPG key verification |
+| `bluefield-doca-3-3-0.sh` | 3.3.0 | 4.14.0-13878 | 6.8.0-1016 | noble | Uses [trusted=yes] as GPG key is unavailable |
+
+Build command:
+
+```shell
+make custom-cloudimg.tar.gz SERIES=<series> ARCH=arm64 CUSTOMIZE=scripts/examples/<script>
+
+Refer to [ubuntu/README.md](../README.md) for full build instructions.

--- a/ubuntu/scripts/examples/bluefield-doca-3-3-0.sh
+++ b/ubuntu/scripts/examples/bluefield-doca-3-3-0.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+export DEBIAN_FRONTEND=noninteractive
+
+BASE_URL="https://linux.mellanox.com/public/repo/doca"
+DPU_ARCH="aarch64"
+DOCA_VERSION="3.3.0"
+KERNEL="6.8.0"
+KSUBVER="1016"
+KVER_DASH="$KERNEL-$KSUBVER"
+KREVISION="20"
+BF_KERNEL_VERSION="$KERNEL.$KSUBVER.17"
+BSP_VERSION="4.14.0-13878"
+BOOTIMAGE_DEB="/tmp/mlxbf-bootimages-signed_${BSP_VERSION}_arm64.deb"
+
+echo "deb [trusted=yes] $BASE_URL/$DOCA_VERSION/ubuntu24.04/$DPU_ARCH ./" | tee /etc/apt/sources.list.d/doca.list
+
+wget -O "$BOOTIMAGE_DEB" "${BASE_URL}/${DOCA_VERSION}/ubuntu24.04/${DPU_ARCH}/mlxbf-bootimages-signed_${BSP_VERSION}_arm64.deb"
+dpkg -i "$BOOTIMAGE_DEB"
+rm -f "$BOOTIMAGE_DEB"
+
+apt-get update
+apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -f \
+    linux-bluefield=$BF_KERNEL_VERSION \
+    linux-bluefield-headers-$KVER_DASH=$KVER_DASH.$KREVISION \
+    linux-bluefield-tools-$KVER_DASH=$KVER_DASH.$KREVISION \
+    linux-buildinfo-$KVER_DASH-bluefield=$KVER_DASH.$KREVISION \
+    linux-headers-$KVER_DASH-bluefield=$KVER_DASH.$KREVISION \
+    linux-headers-bluefield=$BF_KERNEL_VERSION \
+    linux-image-$KVER_DASH-bluefield=$KVER_DASH.$KREVISION \
+    linux-image-bluefield=$BF_KERNEL_VERSION \
+    linux-modules-$KVER_DASH-bluefield=$KVER_DASH.$KREVISION \
+    linux-modules-extra-$KVER_DASH-bluefield=$KVER_DASH.$KREVISION \
+    linux-tools-$KVER_DASH-bluefield=$KVER_DASH.$KREVISION \
+    linux-tools-bluefield=$BF_KERNEL_VERSION \
+    bridge-utils \
+    conntrack \
+    dmidecode \
+    ebtables \
+    edac-utils \
+    iptables-persistent \
+    iputils-arping \
+    iputils-ping \
+    iputils-tracepath \
+    irqbalance \
+    jq \
+    curl \
+    kexec-tools \
+    lldpd \
+    lm-sensors \
+    mstflint \
+    net-tools \
+    nftables \
+    tcpdump \
+    vim \
+    mlnx-ofed-kernel-modules \
+    doca-runtime \
+    doca-devel \
+    libxlio \
+    libxlio-dev \
+    libxlio-utils \
+    strongswan \
+    mlnx-fw-updater-signed \
+    bf3-bmc-fw-signed \
+    bf3-bmc-gi-signed \
+    bf3-cec-fw-signed
+
+apt-mark hold linux-bluefield linux-headers-bluefield linux-image-bluefield \
+    linux-tools-bluefield \
+    mlnx-ofed-kernel-modules doca-runtime doca-devel mlnx-fw-updater-signed
+
+apt-mark hold linux-image-$KVER_DASH-bluefield linux-modules-$KVER_DASH-bluefield \
+    linux-modules-extra-$KVER_DASH-bluefield linux-headers-$KVER_DASH-bluefield
+
+rm /etc/apt/sources.list.d/doca.list
+sed -i -E "s/(_unsigned|_prod|_dev)/_packer_maas/;" /etc/mlnx-release
+sed -i -e "s/FORCE_MODE=.*/FORCE_MODE=yes/" /etc/infiniband/openib.conf
+
+systemctl enable NetworkManager.service || true
+systemctl enable NetworkManager-wait-online.service || true
+systemctl enable acpid.service || true
+systemctl enable mlx-openipmi.service || true
+systemctl enable mlx_ipmid.service || true
+systemctl enable set_emu_param.service || true
+systemctl disable openvswitch-ipsec || true
+systemctl disable srp_daemon.service || true
+systemctl disable ibacm.service || true
+systemctl disable opensmd.service || true
+systemctl disable unattended-upgrades.service || true
+systemctl disable apt-daily-upgrade.timer || true
+systemctl disable ModemManager.service || true
+
+sed -i \
+    -e 's/^GRUB_CMDLINE_LINUX_DEFAULT=.*/GRUB_CMDLINE_LINUX_DEFAULT="text debug console=hvc0 console=ttyAMA0 earlycon=pl011,0x13010000 fixrtc net.ifnames=0 biosdevname=0 iommu.passthrough=1 earlyprintk=efi,keep"/' \
+    -e 's/^GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX=""/' \
+    /etc/default/grub
+rm /etc/cloud/cloud.cfg.d/91-dib-cloud-init-datasources.cfg
+rm /etc/netplan/60-mlnx.yaml
+rm /etc/udev/rules.d/92-oob_net.rules
+sed -i 's/CREATE_OVS_BRIDGES="yes"/CREATE_OVS_BRIDGES="no"/' /etc/mellanox/mlnx-ovs.conf
+ovs-vsctl --no-wait set Open_vSwitch . other_config:hw-offload=true
+sed -i 's/OVS_DOCA="no"/OVS_DOCA="yes"/' /etc/mellanox/mlnx-ovs.conf
+
+mkdir -p /curtin
+echo -n "linux-bluefield=$BF_KERNEL_VERSION" > /curtin/CUSTOM_KERNEL


### PR DESCRIPTION
For release of DOCA 3.3.0, the BSP has been updated to 4.14.0-13878 and the base kernel to 6.8.0-1016. This PR adds a new example targeting DOCA 3.3.0 LTS, highlighting the differences from previous releases.

Compared to the existing DOCA 3.2.1 example, this PR also:
- Uses `[trusted=yes]` instead of GPG key verification for the NVIDIA repository, as the GPG key is no longer available for direct download.
- Adds BF3 firmware packages (bf3-bmc-fw-signed, bf3-bmc-gi-signed, bf3-cec-fw-signed).