### PR TITLE
Fix typos and bugs in OS README files

### DIFF
--- a/alma10/README.md
+++ b/alma10/README.md
@@ -13,7 +13,7 @@ The Packer template in this directory creates a Alma 10 AMD64/ARM64 image for us
 * ovmf
 * cloud-image-utils
 * parted
-* [Packer.](https://www.packer.io/intro/getting-started/install.html), v1.11.0 or newer
+* [Packer](https://www.packer.io/intro/getting-started/install.html), v1.11.0 or newer
 
 ## Requirements to deploy the image
 
@@ -27,7 +27,7 @@ You can customize the deployment image by modifying http/alma.ks. See the [RHEL 
 
 The Packer template downloads the Alma ISO image from the Internet. You can tell Packer to use a proxy by setting the HTTP_PROXY environment variable to point to your proxy server. You can also redefine alma_iso_url to a local file. If you want to skip the base image integrity check, set iso_checksum_type to none and remove iso_checksum.
 
-To use a proxy during the installation define the `KS_PROXY` variable in the environment, as bellow:
+To use a proxy during the installation define the `KS_PROXY` variable in the environment, as below:
 
 ```shell
 export KS_PROXY="\"${HTTP_PROXY}\""
@@ -36,7 +36,7 @@ export KS_PROXY="\"${HTTP_PROXY}\""
 # Building the image using a kickstart mirror
 
 To tell Packer to use a specific mirror set the `KS_MIRROR` environment variable
-poiniting to the mirror URL.
+pointing to the mirror URL.
 
 ```shell
 export KS_MIRROR="https://repo.almalinux.org/almalinux/10"
@@ -118,4 +118,4 @@ MAAS uses cloud-init to create ```cloud-user``` account using the ssh keys confi
 ssh -i ~/.ssh/<your_identity_file> cloud-user@<machine-ip-address>
 ```
 
-Next to that, the kickstart script creates an account with both username and password set to  ```alma```. Note that the default sshd configuration in Alma 10 disallows password-based authentication when logging in via ssh, so trying `ssh alma<machine-ip-address>` will fail. Password-based authentication can be enabled by having `PasswordAuthentication yes` in /etc/ssh/sshd_config after logging in with ```cloud-user```. Perhaps there is a way to make that change using kickstart script, but it is not obvious as ```anaconda```, the installer, makes its own changes to sshd_config file during installation. If you know how to do this, a PR is welcome.
+Next to that, the kickstart script creates an account with both username and password set to  ```alma```. Note that the default sshd configuration in Alma 10 disallows password-based authentication when logging in via ssh, so trying `ssh alma@<machine-ip-address>` will fail. Password-based authentication can be enabled by having `PasswordAuthentication yes` in /etc/ssh/sshd_config after logging in with ```cloud-user```. Perhaps there is a way to make that change using kickstart script, but it is not obvious as ```anaconda```, the installer, makes its own changes to sshd_config file during installation. If you know how to do this, a PR is welcome.

--- a/alma8/README.md
+++ b/alma8/README.md
@@ -13,7 +13,7 @@ The Packer template in this directory creates a Alma 8 AMD64/ARM64 image for use
 * ovmf
 * cloud-image-utils
 * parted
-* [Packer.](https://www.packer.io/intro/getting-started/install.html), v1.11.0 or newer
+* [Packer](https://www.packer.io/intro/getting-started/install.html), v1.11.0 or newer
 
 ## Requirements to deploy the image
 
@@ -27,7 +27,7 @@ You can customize the deployment image by modifying http/alma.ks. See the [RHEL 
 
 The Packer template downloads the Alma ISO image from the Internet. You can tell Packer to use a proxy by setting the HTTP_PROXY environment variable to point to your proxy server. You can also redefine alma_iso_url to a local file. If you want to skip the base image integrity check, set iso_checksum_type to none and remove iso_checksum.
 
-To use a proxy during the installation define the `KS_PROXY` variable in the environment, as bellow:
+To use a proxy during the installation define the `KS_PROXY` variable in the environment, as below:
 
 ```shell
 export KS_PROXY="\"${HTTP_PROXY}\""
@@ -36,7 +36,7 @@ export KS_PROXY="\"${HTTP_PROXY}\""
 # Building the image using a kickstart mirror
 
 To tell Packer to use a specific mirror set the `KS_MIRROR` environment variable
-poiniting to the mirror URL.
+pointing to the mirror URL.
 
 ```shell
 export KS_MIRROR="https://repo.almalinux.org/almalinux/8"
@@ -118,4 +118,4 @@ MAAS uses cloud-init to create ```cloud-user``` account using the ssh keys confi
 ssh -i ~/.ssh/<your_identity_file> cloud-user@<machine-ip-address>
 ```
 
-Next to that, the kickstart script creates an account with both username and password set to  ```alma```. Note that the default sshd configuration in Alma 9 disallows password-based authentication when logging in via ssh, so trying `ssh alma<machine-ip-address>` will fail. Password-based authentication can be enabled by having `PasswordAuthentication yes` in /etc/ssh/sshd_config after logging in with ```cloud-user```. Perhaps there is a way to make that change using kickstart script, but it is not obvious as ```anaconda```, the installer, makes its own changes to sshd_config file during installation. If you know how to do this, a PR is welcome.
+Next to that, the kickstart script creates an account with both username and password set to  ```alma```. Note that the default sshd configuration in Alma 8 disallows password-based authentication when logging in via ssh, so trying `ssh alma@<machine-ip-address>` will fail. Password-based authentication can be enabled by having `PasswordAuthentication yes` in /etc/ssh/sshd_config after logging in with ```cloud-user```. Perhaps there is a way to make that change using kickstart script, but it is not obvious as ```anaconda```, the installer, makes its own changes to sshd_config file during installation. If you know how to do this, a PR is welcome.

--- a/alma9/README.md
+++ b/alma9/README.md
@@ -13,7 +13,7 @@ The Packer template in this directory creates a Alma 9 AMD64/ARM64 image for use
 * ovmf
 * cloud-image-utils
 * parted
-* [Packer.](https://www.packer.io/intro/getting-started/install.html), v1.11.0 or newer
+* [Packer](https://www.packer.io/intro/getting-started/install.html), v1.11.0 or newer
 
 ## Requirements to deploy the image
 
@@ -27,7 +27,7 @@ You can customize the deployment image by modifying http/alma.ks. See the [RHEL 
 
 The Packer template downloads the Alma ISO image from the Internet. You can tell Packer to use a proxy by setting the HTTP_PROXY environment variable to point to your proxy server. You can also redefine alma_iso_url to a local file. If you want to skip the base image integrity check, set iso_checksum_type to none and remove iso_checksum.
 
-To use a proxy during the installation define the `KS_PROXY` variable in the environment, as bellow:
+To use a proxy during the installation define the `KS_PROXY` variable in the environment, as below:
 
 ```shell
 export KS_PROXY="\"${HTTP_PROXY}\""
@@ -36,7 +36,7 @@ export KS_PROXY="\"${HTTP_PROXY}\""
 # Building the image using a kickstart mirror
 
 To tell Packer to use a specific mirror set the `KS_MIRROR` environment variable
-poiniting to the mirror URL.
+pointing to the mirror URL.
 
 ```shell
 export KS_MIRROR="https://repo.almalinux.org/almalinux/9"
@@ -118,4 +118,4 @@ MAAS uses cloud-init to create ```cloud-user``` account using the ssh keys confi
 ssh -i ~/.ssh/<your_identity_file> cloud-user@<machine-ip-address>
 ```
 
-Next to that, the kickstart script creates an account with both username and password set to  ```alma```. Note that the default sshd configuration in Alma 9 disallows password-based authentication when logging in via ssh, so trying `ssh alma<machine-ip-address>` will fail. Password-based authentication can be enabled by having `PasswordAuthentication yes` in /etc/ssh/sshd_config after logging in with ```cloud-user```. Perhaps there is a way to make that change using kickstart script, but it is not obvious as ```anaconda```, the installer, makes its own changes to sshd_config file during installation. If you know how to do this, a PR is welcome.
+Next to that, the kickstart script creates an account with both username and password set to  ```alma```. Note that the default sshd configuration in Alma 9 disallows password-based authentication when logging in via ssh, so trying `ssh alma@<machine-ip-address>` will fail. Password-based authentication can be enabled by having `PasswordAuthentication yes` in /etc/ssh/sshd_config after logging in with ```cloud-user```. Perhaps there is a way to make that change using kickstart script, but it is not obvious as ```anaconda```, the installer, makes its own changes to sshd_config file during installation. If you know how to do this, a PR is welcome.

--- a/debian/README.md
+++ b/debian/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The Packer templates in this directory creates Debian images for use with MAAS.
+The Packer templates in this directory create Debian images for use with MAAS.
 
 ## Prerequisites (to create the image)
 
@@ -31,12 +31,12 @@ in BIOS and UEFI modes. The process currently works with the following Debian se
 
 ## Supported Architectures
 
-Currently amd64 (x86_64) and arm64 (aarch64) architectures are supported with aemd64
+Currently amd64 (x86_64) and arm64 (aarch64) architectures are supported with amd64
 being the default.
 
 ## Known Issues
 
-* UEFI images fro Debian 10 (Buster) and 11 (Bullseye) are usable on both BIOS and 
+* UEFI images for Debian 10 (Buster) and 11 (Bullseye) are usable on both BIOS and 
 UEFI systems. However for Debian 12 (Bookworm) explicit images are required to
 support BIOS and UEFI modes. See BOOT make parameter for more details.
 
@@ -49,7 +49,7 @@ results in an image that is very close to the ones that are on
 
 ### Building the image
 
-The build the image you give the template a script which has all the
+To build the image you give the template a script which has all the
 customizations:
 
 ```shell
@@ -68,7 +68,7 @@ Using make:
 make debian SERIES=bookworm
 ```
 
-#### Accessing external files from you script
+#### Accessing external files from your script
 
 If you want to put or use some files in the image, you can put those in the `http` directory.
 

--- a/rocky10/README.md
+++ b/rocky10/README.md
@@ -13,7 +13,7 @@ The Packer template in this directory creates a Rocky 10 AMD64/ARM64 image for u
 * ovmf
 * cloud-image-utils
 * parted
-* [Packer.](https://www.packer.io/intro/getting-started/install.html), v1.11.0 or newer
+* [Packer](https://www.packer.io/intro/getting-started/install.html), v1.11.0 or newer
 
 ## Requirements to deploy the image
 
@@ -28,7 +28,7 @@ You can customize the deployment image by modifying http/rocky.ks. See the [RHEL
 
 The Packer template downloads the Rocky ISO image from the Internet. You can tell Packer to use a proxy by setting the HTTP_PROXY environment variable to point to your proxy server. You can also redefine rocky_iso_url to a local file. If you want to skip the base image integrity check, set iso_checksum_type to none and remove iso_checksum.
 
-To use a proxy during the installation define the `KS_PROXY` variable in the environment, as bellow:
+To use a proxy during the installation define the `KS_PROXY` variable in the environment, as below:
 
 ```shell
 export KS_PROXY="\"${HTTP_PROXY}\""
@@ -37,7 +37,7 @@ export KS_PROXY="\"${HTTP_PROXY}\""
 # Building the image using a kickstart mirror
 
 To tell Packer to use a specific mirror set the `KS_MIRROR` environment variable
-poiniting to the mirror URL.
+pointing to the mirror URL.
 
 ```shell
 export KS_MIRROR="https://dl.rockylinux.org/pub/rocky/10"

--- a/rocky8/README.md
+++ b/rocky8/README.md
@@ -13,7 +13,7 @@ The Packer template in this directory creates a Rocky 8 AMD64/ARM64 image for us
 * ovmf
 * cloud-image-utils
 * parted
-* [Packer.](https://www.packer.io/intro/getting-started/install.html), v1.11.0 or newer
+* [Packer](https://www.packer.io/intro/getting-started/install.html), v1.11.0 or newer
 
 ## Requirements to deploy the image
 
@@ -28,7 +28,7 @@ You can customize the deployment image by modifying http/rocky.ks. See the [RHEL
 
 The Packer template downloads the Rocky ISO image from the Internet. You can tell Packer to use a proxy by setting the HTTP_PROXY environment variable to point to your proxy server. You can also redefine rocky_iso_url to a local file. If you want to skip the base image integrity check, set iso_checksum_type to none and remove iso_checksum.
 
-To use a proxy during the installation define the `KS_PROXY` variable in the environment, as bellow:
+To use a proxy during the installation define the `KS_PROXY` variable in the environment, as below:
 
 ```shell
 export KS_PROXY="\"${HTTP_PROXY}\""
@@ -37,7 +37,7 @@ export KS_PROXY="\"${HTTP_PROXY}\""
 # Building the image using a kickstart mirror
 
 To tell Packer to use a specific mirror set the `KS_MIRROR` environment variable
-poiniting to the mirror URL.
+pointing to the mirror URL.
 
 ```shell
 export KS_MIRROR="https://dl.rockylinux.org/pub/rocky/8"

--- a/rocky9/README.md
+++ b/rocky9/README.md
@@ -13,7 +13,7 @@ The Packer template in this directory creates a Rocky 9 AMD64/ARM64 image for us
 * ovmf
 * cloud-image-utils
 * parted
-* [Packer.](https://www.packer.io/intro/getting-started/install.html), v1.11.0 or newer
+* [Packer](https://www.packer.io/intro/getting-started/install.html), v1.11.0 or newer
 
 ## Requirements to deploy the image
 
@@ -28,7 +28,7 @@ You can customize the deployment image by modifying http/rocky.ks. See the [RHEL
 
 The Packer template downloads the Rocky ISO image from the Internet. You can tell Packer to use a proxy by setting the HTTP_PROXY environment variable to point to your proxy server. You can also redefine rocky_iso_url to a local file. If you want to skip the base image integrity check, set iso_checksum_type to none and remove iso_checksum.
 
-To use a proxy during the installation define the `KS_PROXY` variable in the environment, as bellow:
+To use a proxy during the installation define the `KS_PROXY` variable in the environment, as below:
 
 ```shell
 export KS_PROXY="\"${HTTP_PROXY}\""
@@ -37,7 +37,7 @@ export KS_PROXY="\"${HTTP_PROXY}\""
 # Building the image using a kickstart mirror
 
 To tell Packer to use a specific mirror set the `KS_MIRROR` environment variable
-poiniting to the mirror URL.
+pointing to the mirror URL.
 
 ```shell
 export KS_MIRROR="https://dl.rockylinux.org/pub/rocky/9"

--- a/ubuntu/README.md
+++ b/ubuntu/README.md
@@ -2,10 +2,10 @@
 
 ## Introduction
 
-The Packer templates in this directory creates Ubuntu images for use with MAAS.
+The Packer templates in this directory create Ubuntu images for use with MAAS.
 
-This templates supports building amd64 and arm64 images in all three supported
-modes including, cloudimg, flat as wellas lvm.
+These templates support building amd64 and arm64 images in all three supported
+modes including cloudimg, flat, and lvm.
 
 ## Prerequisites (to create the image)
 
@@ -31,7 +31,7 @@ results in an image that is very close to the ones that are on
 
 ### Building the image
 
-The build the image you give the template a script which has all the
+To build the image you give the template a script which has all the
 customizations:
 
 ```shell
@@ -50,7 +50,7 @@ Building using make:
 make custom-cloudimg.tar.gz SERIES=resolute
 ```
 
-#### Accessing external files from you script
+#### Accessing external files from your script
 
 If you want to put or use some files in the image, you can put those in the `http` directory.
 

--- a/windows/README.md
+++ b/windows/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The Packer templates in this directory creates Windows Server images for use with MAAS.
+The Packer templates in this directory create Windows Server images for use with MAAS.
 
 
 ## Prerequisites (to create the image)
@@ -24,7 +24,7 @@ The Packer templates in this directory creates Windows Server images for use wit
 
 ## Supported Microsoft Windows Versions
 
-This process has been build and deployment tested with the following versions of
+This process has been built and deployment tested with the following versions of
 Microsoft Windows:
 
 * Azure Local 23H2
@@ -49,7 +49,7 @@ This process also installs the latest VirtIO drivers as well as Cloudbase-init.
 
 ## Obtaining Microsoft Windows ISO images
 
-You can obtains Microsoft Windows Evaluation ISO/VHDX images from the following links:
+You can obtain Microsoft Windows Evaluation ISO/VHDX images from the following links:
 
 * [Windows Server 2025](https://www.microsoft.com/en-us/evalcenter/download-windows-server-2025)
 * [Windows Server 2022](https://www.microsoft.com/en-us/evalcenter/download-windows-server-2022)
@@ -63,7 +63,7 @@ To download an ISO image for Azure Local (formerly Azure Stack HCI), [follow the
 
 ### Building the image
 
-The build the image you give the template a script which has all the
+To build the image you give the template a script which has all the
 customization:
 
 ```shell
@@ -86,14 +86,14 @@ Currently uefi is the only supported value.
 
 The edition of a targeted ISO image. It defaults to PRO for Microsoft Windows 10/11
 and SERVERSTANDARD for Microsoft Windows Servers. Many Microsoft Windows Server ISO
-images do contain multiple editions and this prarameter is useful to build a particular
+images do contain multiple editions and this parameter is useful to build a particular
 edition such as Standard or Datacenter etc.
 
 #### HEADLESS
 
 Whether VNC viewer should not be launched. Default is set to false. This requires GTK
 or SDL libraries to be present on the machine. If building on headless servers, set this
-to true. The use a VNC client to connecto to the displayed VNC port during the build.
+to true. Then use a VNC client to connect to the displayed VNC port during the build.
 
 #### ISO
 
@@ -106,7 +106,7 @@ Enable (1) or Disable (0) verbose packer logs. The default value is set to 0.
 
 #### PKEY
 
-User supplied Microsoft Windows Product Key. When usimg KMS, you can obtain the
+User supplied Microsoft Windows Product Key. When using KMS, you can obtain the
 activation keys from the link below:
 
 * [KMS Client Activation and Product Keys](https://learn.microsoft.com/en-us/windows-server/get-started/kms-client-activation-keys)


### PR DESCRIPTION
## Summary

Fix spelling errors, grammar issues, and two functional bugs across nine README files.

### Bug fixes (functional)
- **alma8/9/10**: Add missing `@` in SSH command examples — `ssh alma<machine-ip-address>` is not a valid SSH command; fixed to `ssh alma@<machine-ip-address>`
- **alma8**: Fix version mismatch — the Alma 8 README incorrectly states "Alma 9 disallows password-based authentication" when it should say "Alma 8"

### Typo and grammar fixes
- **rocky8/9/10, alma8/9/10**: `bellow` -> `below`, `poiniting` -> `pointing`, `[Packer.]` -> `[Packer]` (stray period in link text)
- **ubuntu**: `creates` -> `create` (subject-verb agreement), `This templates supports` -> `These templates support`, `as wellas` -> `and`, `The build the image` -> `To build the image`, `from you script` -> `from your script`
- **windows**: `creates` -> `create`, `build` -> `built`, `obtains` -> `obtain`, `The build` -> `To build`, `prarameter` -> `parameter`, `The use` -> `Then use`, `connecto` -> `connect`, `usimg` -> `using`
- **debian**: `creates` -> `create`, `aemd64` -> `amd64`, `fro` -> `for`, `The build` -> `To build`, `from you` -> `from your`

### Files changed
- `alma8/README.md`, `alma9/README.md`, `alma10/README.md`
- `rocky8/README.md`, `rocky9/README.md`, `rocky10/README.md`
- `ubuntu/README.md`, `windows/README.md`, `debian/README.md`