### PR TITLE
Add support for Anolis OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Refer to the `README.md` inside each OS directory for supported parameters.
 | [AlmaLinux 8](alma8/README.md)       | Beta               | x86_64 / aarch64  | >= 3.3           |
 | [AlmaLinux 9](alma9/README.md)       | Beta               | x86_64 / aarch64  | >= 3.3           |
 | [AlmaLinux 10](alma10/README.md)     | Beta               | x86_64 / aarch64  | >= 3.3           |
+| [Anolis OS 23](anolis/README.md)     | Beta               | x86_64 / aarch64  | >= 3.3           |
 | [AzureLinux 2.0](azurelinux/README.md)    | Beta               | x86_64            | >= 3.3           |
 | [CentOS 6](centos6/README.md)          | EOL                | x86_64            | >= 1.6           |
 | [CentOS 7](centos7/README.md)          | EOL                | x86_64            | >= 2.3           |

--- a/anolis/Makefile
+++ b/anolis/Makefile
@@ -1,0 +1,66 @@
+#!/usr/bin/make -f
+
+include ../scripts/check.mk
+
+PACKER ?= packer
+PACKER_LOG ?= 0
+ISO ?= AnolisOS-23.4-x86_64-boot.iso
+TIMEOUT ?= 1h
+ARCH ?= x86_64
+VERSION ?= 23
+
+# Detect if running on ARM host
+ifeq ($(shell uname -m),aarch64)
+    HOST_IS_ARM = true
+else
+    HOST_IS_ARM = false
+endif
+
+ifeq ($(wildcard /usr/share/OVMF/OVMF_CODE.fd),)
+	OVMF_SFX ?= _4M
+else
+	OVMF_SFX ?=
+endif
+
+export PACKER_LOG
+
+# Fallback
+ifeq ($(strip $(ARCH)),amd64)
+	ARCH = x86_64
+endif
+
+.PHONY: all clean
+
+all: anolis.tar.gz
+
+$(eval $(call check_packages_deps))
+
+lint:
+	packer validate .
+	packer fmt -check -diff .
+
+format:
+	packer fmt .
+
+OVMF_VARS.fd: /usr/share/OVMF/OVMF_VARS${OVMF_SFX}.fd
+	cp -v $< ${ARCH}_VARS.fd
+
+SIZE_VARS.fd:
+ifeq ($(strip $(ARCH)),aarch64)
+	truncate -s 64m ${ARCH}_VARS.fd
+else
+	truncate -s 2m ${ARCH}_VARS.fd
+endif
+
+anolis.tar.gz: check-deps clean OVMF_VARS.fd SIZE_VARS.fd
+	${PACKER} init anolis.pkr.hcl && ${PACKER} build \
+							-var architecture=${ARCH} \
+							-var host_is_arm=${HOST_IS_ARM} \
+							-var ovmf_suffix=${OVMF_SFX} \
+							-var anolis_iso_path=${ISO} \
+							-var timeout=${TIMEOUT} \
+							-var version=${VERSION} \
+							anolis.pkr.hcl
+
+clean:
+	${RM} -rf *.fd output-anolis anolis.tar.gz

--- a/anolis/README.md
+++ b/anolis/README.md
@@ -1,0 +1,76 @@
+# Anolis OS Packer Template for MAAS
+
+## Introduction
+
+The Packer template in this directory creates a Anolis OS AMD64/ARM64 image for use with MAAS.
+
+## Prerequisites (to create the image)
+
+* A machine running Ubuntu 22.04+ with the ability to run KVM virtual machines.
+* qemu-utils, libnbd-bin, nbdkit and fuse2fs
+* [Packer](https://www.packer.io/intro/getting-started/install.html), v1.8.0 or newer
+* The [Anolis OS ISO images](https://openanolis.cn/download?lang=en)
+
+## Requirements (to deploy the image)
+
+* [MAAS](https://maas.io) 3.3+
+* [Curtin](https://launchpad.net/curtin) 22.1+
+
+## Customizing the Image
+
+The deployment image may be customized by modifying http/anolis.ks.pkrtpl.hcl. See the [pykickstart documentation](https://pykickstart.readthedocs.io/en/latest/kickstart-docs.html) for more information.
+
+## Building an image
+
+You can easily build the image using the Makefile (boot or full ISO):
+
+```shell
+make ISO=/PATH/TO/AnolisOS-23.5-x86_64-boot.iso
+```
+
+Note: anolis.pkr.hcl is configured to run Packer in headless mode. Only Packer
+output will be seen. If you wish to see the installation output connect to the
+VNC port given in the Packer output or change the value of headless to false in
+anolis.pkr.hcl.
+
+Installation is non-interactive.
+
+### Makefile Parameters
+
+#### ARCH
+
+Defaults to x86_64 to build AMD64 compatible images. In order to build ARM64 images, use ARCH=aarch64
+
+#### ISO
+
+The path to the installation ISO image for Anolis OS.
+
+#### TIMEOUT
+
+The timeout to apply when building the image. The default value is set to 1h.
+
+#### VERSION
+
+Anolis OS version. Default is currently set to 23.
+
+## Uploading an image to MAAS
+
+```shell
+maas $PROFILE boot-resources create \
+    name='custom/anolis' title='Anolis OS Custom' \
+    architecture='amd64/generic' filetype='tgz' \
+    base_image='rhel/10' content@=anolis.tar.gz
+```
+
+For ARM64, use:
+
+```shell
+maas $PROFILE boot-resources create \
+    name='custom/anolis' title='Anolis OS Custom' \
+    architecture='arm64/generic' filetype='tgz' \
+    base_image='rhel/10' content@=anolis.tar.gz
+```
+
+## Default Username
+
+The default username is ```admin```

--- a/anolis/anolis.pkr.hcl
+++ b/anolis/anolis.pkr.hcl
@@ -1,0 +1,144 @@
+packer {
+  required_version = ">= 1.11.0"
+  required_plugins {
+    qemu = {
+      version = ">= 1.1.0, < 1.1.2"
+      source  = "github.com/hashicorp/qemu"
+    }
+  }
+}
+
+variable ks_proxy {
+  type    = string
+  default = "${env("KS_PROXY")}"
+}
+
+variable ks_mirror {
+  type    = string
+  default = "${env("KS_MIRROR")}"
+}
+
+variable "filename" {
+  type        = string
+  default     = "anolis.tar.gz"
+  description = "The filename of the tarball to produce"
+}
+
+variable "anolis_iso_path" {
+  type    = string
+  default = "${env("ANOLIS_ISO_PATH")}"
+}
+
+variable "timeout" {
+  type        = string
+  default     = "1h"
+  description = "Timeout for building the image"
+}
+
+variable "architecture" {
+  type        = string
+  default     = "amd64"
+  description = "The architecture to build the image for (amd64 or arm64)"
+}
+
+variable "host_is_arm" {
+  type        = bool
+  default     = false
+  description = "The host architecture is aarch64"
+}
+
+variable "ovmf_suffix" {
+  type        = string
+  default     = ""
+  description = "Suffix for OVMF CODE and VARS files. Newer systems such as Noble use _4M."
+}
+
+variable "version" {
+  type    = string
+  default = "23"
+}
+
+locals {
+  qemu_arch = {
+    "x86_64"  = "x86_64"
+    "aarch64" = "aarch64"
+  }
+  uefi_imp = {
+    "x86_64"  = "OVMF"
+    "aarch64" = "AAVMF"
+  }
+  uefi_sfx = {
+    "x86_64"  = "${var.ovmf_suffix}"
+    "aarch64" = ""
+  }
+  qemu_machine = {
+    "x86_64"  = "accel=kvm"
+    "aarch64" = var.host_is_arm ? "virt,accel=kvm" : "virt"
+  }
+  qemu_cpu = {
+    "x86_64"  = "host"
+    "aarch64" = var.host_is_arm ? "host" : "max"
+  }
+  
+  ks_proxy           = var.ks_proxy != "" ? "--proxy=${var.ks_proxy}" : ""
+  ks_os_repos        = var.ks_mirror != "" ? "--url=${var.ks_mirror}/os/${var.architecture}/os" : "--url='https://mirrors.openanolis.cn/anolis/${var.version}/os/${var.architecture}/os'"
+  ks_updates_repos = var.ks_mirror != "" ? "--baseurl=${var.ks_mirror}/updates/${var.architecture}/os" : "--baseurl='https://mirrors.openanolis.cn/anolis/${var.version}/updates/${var.architecture}/os'"
+}
+
+
+source "qemu" "anolis" {
+  boot_command     = ["<up><wait>", "e", "<down><down><down><left>", " console=ttyS0 inst.cmdline inst.text inst.ks=http://{{.HTTPIP}}:{{.HTTPPort}}/anolis.ks <f10>"]
+  boot_wait        = "5s"
+  communicator     = "none"
+  disk_size        = "8G"
+  headless         = true
+  iso_checksum     = "none"
+  iso_url          = var.anolis_iso_path
+  memory           = 2048
+  cpus             = 4
+  qemu_binary      = "qemu-system-${lookup(local.qemu_arch, var.architecture, "")}"
+  qemuargs = [
+    ["-serial", "stdio"],
+    ["-boot", "strict=off"],
+    ["-device", "qemu-xhci"],
+    ["-device", "usb-kbd"],
+    ["-device", "virtio-net-pci,netdev=net0"],
+    ["-netdev", "user,id=net0"],
+    ["-device", "virtio-blk-pci,drive=drive0,bootindex=0"],
+    ["-device", "virtio-blk-pci,drive=cdrom0,bootindex=1"],
+    ["-machine", "${lookup(local.qemu_machine, var.architecture, "")}"],
+    ["-cpu", "${lookup(local.qemu_cpu, var.architecture, "")}"],
+    ["-device", "virtio-gpu-pci"],
+    ["-global", "driver=cfi.pflash01,property=secure,value=off"],
+    ["-drive", "if=pflash,format=raw,unit=0,id=ovmf_code,readonly=on,file=/usr/share/${lookup(local.uefi_imp, var.architecture, "")}/${lookup(local.uefi_imp, var.architecture, "")}_CODE${lookup(local.uefi_sfx, var.architecture, "")}.fd"],
+    ["-drive", "if=pflash,format=raw,unit=1,id=ovmf_vars,file=${var.architecture}_VARS.fd"],
+    ["-drive", "file=output-anolis/packer-anolis,if=none,id=drive0,cache=writeback,discard=ignore,format=qcow2"],
+    ["-drive", "file=${var.anolis_iso_path},if=none,id=cdrom0,media=cdrom"]
+  ]
+  shutdown_timeout = var.timeout
+  http_content = {
+    "/anolis.ks" = templatefile("${path.root}/http/anolis.ks.pkrtpl.hcl",
+      {
+        KS_PROXY           = local.ks_proxy,
+        KS_OS_REPOS        = local.ks_os_repos,
+        KS_UPDATES_REPOS = local.ks_updates_repos,
+      }
+    )
+  }
+}
+
+build {
+  sources = ["source.qemu.anolis"]
+
+  post-processor "shell-local" {
+    inline = [
+      "SOURCE=${source.name}",
+      "OUTPUT=${var.filename}",
+      "ROOT_PARTITION=2",
+      "source ../scripts/fuse-nbd",
+      "source ../scripts/fuse-tar-root",
+      "rm -rf output-${source.name}",
+    ]
+    inline_shebang = "/bin/bash -e"
+  }
+}

--- a/anolis/curtin/curtin-hooks
+++ b/anolis/curtin/curtin-hooks
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import os
+import shutil
+import platform
+
+from curtin import distro, util
+from curtin.config import load_command_config
+from curtin.log import LOG
+from curtin.paths import target_path
+from curtin.util import load_command_environment, ChrootableTarget
+from curtin.commands import curthooks
+
+def run_hook_in_target(target, hook):
+    """Look for "hook" in "target" and run in a chroot"""
+    target_hook = target_path(target, '/curtin/' + hook)
+    if os.path.isfile(target_hook):
+        LOG.debug("running %s" % target_hook)
+        with ChrootableTarget(target=target) as in_chroot:
+            in_chroot.subp(['/curtin/' + hook])
+        return True
+    return False
+
+def curthook(cfg, target, state):
+    """Configure network and bootloader"""
+    LOG.info('Running curtin builtin curthooks')
+    state_etcd = os.path.split(state['fstab'])[0]
+    machine = platform.machine()
+
+    distro_info = distro.get_distroinfo(target=target)
+    if not distro_info:
+        raise RuntimeError('Failed to determine target distro')
+    osfamily = distro_info.family
+    LOG.info('Configuring target system for distro: %s osfamily: %s',
+             distro_info.variant, osfamily)
+    
+    sources = cfg.get('sources', {})
+    dd_image = len(util.get_dd_images(sources)) > 0
+
+    curthooks.disable_overlayroot(cfg, target)
+    curthooks.disable_update_initramfs(cfg, target, machine)
+    
+    if not dd_image:
+        curthooks.configure_iscsi(cfg, state_etcd, target, osfamily=osfamily)
+        curthooks.configure_mdadm(cfg, state_etcd, target, osfamily=osfamily)
+        curthooks.copy_fstab(state.get('fstab'), target)
+        curthooks.add_swap(cfg, target, state.get('fstab'))
+
+    curthooks.apply_networking(target, state)
+    curthooks.handle_pollinate_user_agent(cfg, target)
+    
+    # set cloud-init maas datasource
+    if cfg.get('cloudconfig'):
+        curthooks.handle_cloudconfig(
+                      cfg['cloudconfig'],
+                      base_dir=target_path(target,
+                                                 'etc/cloud/cloud.cfg.d'))
+
+    run_hook_in_target(target, 'setup-bootloader')
+
+def cleanup():
+    """Remove curtin-hooks so its as if we were never here."""
+    curtin_dir = os.path.dirname(__file__)
+    shutil.rmtree(curtin_dir)
+
+
+def main():
+    state = load_command_environment()
+    config = load_command_config(None, state)
+    target = state['target']
+
+    curthook(config, target, state)
+    cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/anolis/curtin/setup-bootloader
+++ b/anolis/curtin/setup-bootloader
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Update All initramfs files
+for kernel in $(ls /lib/modules/); do
+  dracut --force /boot/initramfs-${kernel}.img ${kernel}
+done
+
+# Reinstall shim
+dnf reinstall -y shim-*
+
+# Generate the GRUB config file
+mkdir -p /boot/efi/EFI/anolis/
+grub2-mkconfig -o /boot/efi/EFI/anolis/grub.cfg
+
+# Install GRUB and update the configuration
+if [ -d /sys/firmware/efi/efivars/ ]; then
+        # Fix boot delays due to PXE loop
+        cp /boot/efi/EFI/anolis/grub* /boot/efi/EFI/boot/
+        cp /boot/efi/EFI/anolis/*.efi /boot/efi/EFI/boot/
+else
+        grub_dev="/dev/$(lsblk -r | grep 'part /$' | awk '{print $1}' | sed s/[0-9]//g)"
+
+        grub2-install \
+            --target=i386-pc \
+            --recheck ${grub_dev}
+fi
+exit 0

--- a/anolis/http/anolis.ks.pkrtpl.hcl
+++ b/anolis/http/anolis.ks.pkrtpl.hcl
@@ -1,0 +1,97 @@
+poweroff
+eula --agreed
+lang en_US.UTF-8
+keyboard us
+timezone UTC --utc
+
+network --device eth0 --bootproto=dhcp
+selinux --enforcing
+
+ignoredisk --only-use=vda
+bootloader --disabled
+zerombr
+clearpart --all --initlabel --drives=vda
+part swap --size=2048
+part / --fstype=ext4 --grow --size=1
+
+# Anolis OS 23 x86_64 network installation source and update repository.
+url ${KS_OS_REPOS} ${KS_PROXY}
+repo --name="anolis23-updates" ${KS_UPDATES_REPOS} ${KS_PROXY}
+
+# Lock direct root login. Use the sudo-capable admin account instead.
+rootpw --iscrypted --lock '$6$Dl49Z0NTgdGHgXC6$hckqAiDpjhO720FvC8qoXQ8x9cXxXpys5Ecq6W386a9rT9oFQWUipvfS2hZM5D0lAeg9oPdgcRdBzZDL1mb/1.'
+user --name=admin --groups=wheel --password='$6$Dl49Z0NTgdGHgXC6$hckqAiDpjhO720FvC8qoXQ8x9cXxXpys5Ecq6W386a9rT9oFQWUipvfS2hZM5D0lAeg9oPdgcRdBzZDL1mb/1.' --iscrypted
+
+%post --erroronfail --log=/root/anaconda-post.log
+# Clean up install config not applicable to deployed environments.
+for f in resolv.conf fstab; do
+    rm -f /etc/$f
+    touch /etc/$f
+    chown root:root /etc/$f
+    chmod 644 /etc/$f
+done
+
+rm -f /etc/sysconfig/network-scripts/ifcfg-[^lo]*
+
+# Kickstart copies install boot options. Serial is turned on for logging with
+# Packer which disables console output. Disable it so console output is shown
+# during deployments
+sed -i 's/^GRUB_TERMINAL=.*/GRUB_TERMINAL_OUTPUT="console"/g' /etc/grub.d/10_linux
+sed -i '/GRUB_SERIAL_COMMAND="serial"/d' /etc/grub.d/10_linux
+sed -ri 's/(GRUB_CMDLINE_LINUX=".*)\s+console=ttyS0(.*")/\1\2/' /etc/grub.d/10_linux
+sed -i 's/GRUB_ENABLE_BLSCFG=.*/GRUB_ENABLE_BLSCFG=false/g' /etc/grub.d/10_linux
+
+# Fix curtin ID_LIKE
+echo 'ID_LIKE="rhel centos fedora"' >> /etc/os-release
+
+# Fix curtin boot loader installation
+cp -r /boot/efi/EFI/anolis* /boot/efi/EFI/redhat
+
+sudo tee /etc/cloud/cloud.cfg.d/90-default-user.cfg >/dev/null <<'EOF'
+system_info:
+  default_user:
+    name: admin
+    gecos: Admin User
+    home: /home/admin
+    shell: /bin/bash
+    primary_group: admin
+    groups:
+      - wheel
+      - systemd-journal
+    sudo:
+      - "ALL=(ALL) NOPASSWD:ALL"
+    lock_passwd: true
+EOF
+
+dnf clean all
+%end
+
+%packages --nocore --ignoremissing
+@core
+kernel
+openssh-server
+sudo
+chrony
+grubby
+dnf
+lvm2
+bash-completion
+cloud-init
+# cloud-init only requires python3-oauthlib with MAAS. As such upstream
+# removed this dependency.
+python3-oauthlib
+rsync
+tar
+# grub2-efi-x64 ships grub signed for UEFI secure boot. If grub2-efi-x64-modules
+# is installed grub will be generated on deployment and unsigned which breaks
+# UEFI secure boot.
+grub2-pc
+grub2-efi-*
+shim-*
+grub2-efi-*-modules
+efibootmgr
+nano
+vi
+
+-kmod-hisdk3
+%end


### PR DESCRIPTION
This is a new template to add support for Anolis OS 23. This template currently supports both `x86_64` and `aarch64` architectures. 